### PR TITLE
Setup environment variables

### DIFF
--- a/app/models/index.js
+++ b/app/models/index.js
@@ -7,7 +7,9 @@ const env = process.env.NODE_ENV || 'development'
 const config = require(__dirname + '/../config/config.json')[env]
 const db = {}
 
-config.logging = (msg) => console.log(`[Sequelize]: ${msg}`)
+if (env === 'development') {
+  config.logging = (msg) => console.log(`[Sequelize]: ${msg}`)
+}
 
 let sequelize
 if (config.use_env_variable) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "connect-flash": "^0.1.1",
+        "dotenv": "^16.4.7",
         "govuk-frontend": "^5.8.0",
         "govuk-prototype-kit": "^13.16.2",
         "luxon": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "connect-flash": "^0.1.1",
+    "dotenv": "^16.4.7",
     "govuk-frontend": "^5.8.0",
     "govuk-prototype-kit": "^13.16.2",
     "luxon": "^3.5.0",


### PR DESCRIPTION
This PR adds the `dotenv` package to support using environment variables. This is important when using Google and Ordnance Survey APIs for geocoding addresses and postcode address finding since we do not want to store API keys in code.