### PR TITLE
Add service error pages

### DIFF
--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -1,0 +1,23 @@
+exports.pageNotFound = (req, res) => {
+  res.render('../views/errors/404')
+}
+
+exports.unexpectedError = (req, res) => {
+  res.render('../views/errors/500')
+}
+
+exports.serviceUnavailable = (req, res) => {
+  res.render('../views/errors/503')
+}
+
+exports.unauthorised = (req, res) => {
+  res.render('../views/errors/unauthorised')
+}
+
+exports.accountNotRecognised = (req, res) => {
+  res.render('../views/errors/account-not-recognised')
+}
+
+exports.accountNoOrganisation = (req, res) => {
+  res.render('../views/errors/account-no-organisation')
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -247,6 +247,7 @@ router.get('/503', errorController.serviceUnavailable)
 router.get('/service-unavailable', errorController.serviceUnavailable)
 
 router.get('/unauthorised', errorController.unauthorised)
+router.get('/account-not-authorised', errorController.unauthorised)
 
 router.get('/account-not-recognised', errorController.accountNotRecognised)
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -28,6 +28,7 @@ const passport = {
 /// ------------------------------------------------------------------------ ///
 /// Controller modules
 /// ------------------------------------------------------------------------ ///
+const errorController = require('./controllers/error')
 const providerController = require('./controllers/provider')
 const providerAccreditationController = require('./controllers/providerAccreditation')
 const providerAddressController = require('./controllers/providerAddress')
@@ -231,6 +232,25 @@ router.post('/providers/:providerId/restore', checkIsAuthenticated, providerCont
 router.get('/providers/:providerId', checkIsAuthenticated, providerController.providerDetails)
 
 router.get('/providers', checkIsAuthenticated, providerController.providersList)
+
+/// ------------------------------------------------------------------------ ///
+/// GENERAL ROUTES
+/// ------------------------------------------------------------------------ ///
+
+router.get('/404', checkIsAuthenticated, errorController.pageNotFound)
+router.get('/page-not-found', checkIsAuthenticated, errorController.pageNotFound)
+
+router.get('/500', errorController.unexpectedError)
+router.get('/server-error', errorController.unexpectedError)
+
+router.get('/503', errorController.serviceUnavailable)
+router.get('/service-unavailable', errorController.serviceUnavailable)
+
+router.get('/unauthorised', errorController.unauthorised)
+
+router.get('/account-not-recognised', errorController.accountNotRecognised)
+
+router.get('/account-no-organisation', errorController.accountNoOrganisation)
 
 /// ------------------------------------------------------------------------ ///
 /// AUTOCOMPLETE ROUTES

--- a/app/views/_includes/phase-banner.njk
+++ b/app/views/_includes/phase-banner.njk
@@ -1,7 +1,7 @@
 {{ govukPhaseBanner({
-    tag: {
-      text: "Prototype"
-    },
-    html: 'This is a new service – your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.',
-    classes: "govuk-width-container" + (" govuk-phase-banner--no-border-bottom" if not hidePrimaryNavigation)
-  }) }}
+  tag: {
+    text: "Prototype"
+  },
+  html: 'This is a new service – your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.',
+  classes: "govuk-width-container" + (" govuk-phase-banner--no-border-bottom" if not hidePrimaryNavigation)
+}) }}

--- a/app/views/errors/404.njk
+++ b/app/views/errors/404.njk
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">If you typed a web address, check it is correct.</p>
       <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/errors/404.njk
+++ b/app/views/errors/404.njk
@@ -1,0 +1,14 @@
+{% extends "layouts/main.njk" %}
+
+{% set title = "Page not found" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">If you typed a web address, check it is correct.</p>
+      <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/500.njk
+++ b/app/views/errors/500.njk
@@ -1,0 +1,16 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+{% set title = "Sorry, there’s a problem with the service" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">Try again later.</p>
+      <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/500.njk
+++ b/app/views/errors/500.njk
@@ -11,7 +11,7 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
-      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/errors/500.njk
+++ b/app/views/errors/500.njk
@@ -2,6 +2,7 @@
 
 {% set hidePhaseBanner = true %}
 {% set hideFooterLinks = true %}
+
 {% set title = "Sorry, there’s a problem with the service" %}
 
 {% block content %}

--- a/app/views/errors/503.njk
+++ b/app/views/errors/503.njk
@@ -11,7 +11,7 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">You will be able to use the service from 3pm on Tuesday, 16 April 2025.</p>
       <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
-      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/errors/503.njk
+++ b/app/views/errors/503.njk
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
-      <p class="govuk-body">You will be able to use the service from 3pm on Tuesday, 16 April 2025.</p>
+      <p class="govuk-body">You will be able to use the service from 3pm on Wednesday, 16 April 2025.</p>
       <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
       <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>

--- a/app/views/errors/503.njk
+++ b/app/views/errors/503.njk
@@ -2,6 +2,7 @@
 
 {% set hidePhaseBanner = true %}
 {% set hideFooterLinks = true %}
+
 {% set title = "Sorry, the service is unavailable" %}
 
 {% block content %}

--- a/app/views/errors/503.njk
+++ b/app/views/errors/503.njk
@@ -1,0 +1,16 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+{% set title = "Sorry, the service is unavailable" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You will be able to use the service from 3pm on Tuesday, 16 April 2025.</p>
+      <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/account-no-organisation.njk
+++ b/app/views/errors/account-no-organisation.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/error.njk" %}
 
+{% set hidePrimaryNavigation = true %}
+
 {% set title = "You have not been linked to an organisation yet" %}
 
 {% block content %}

--- a/app/views/errors/account-no-organisation.njk
+++ b/app/views/errors/account-no-organisation.njk
@@ -10,7 +10,7 @@
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">You’ve successfully signed in to {{ serviceName }}, but your account has not been linked to an organisation yet.</p>
       <p class="govuk-body">Your account needs to be linked to an organisation so you can use {{ serviceName }}.</p>
-      <p class="govuk-body">To be added to an organisation, email us at <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">To be added to an organisation, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
       <p class="govuk-body">In your email tell us:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>

--- a/app/views/errors/account-no-organisation.njk
+++ b/app/views/errors/account-no-organisation.njk
@@ -1,0 +1,23 @@
+{% extends "layouts/error.njk" %}
+
+{% set title = "You have not been linked to an organisation yet" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You’ve successfully signed in to {{ serviceName }}, but your account has not been linked to an organisation yet.</p>
+      <p class="govuk-body">Your account needs to be linked to an organisation so you can use {{ serviceName }}.</p>
+      <p class="govuk-body">To be added to an organisation, email us at <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">In your email tell us:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          the email address associated with your {{ serviceName }} account
+        </li>
+        <li>
+          which organisation you’d like to be added to
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -9,7 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">Although you have a DfE Sign-in account, you also need an account on {{ serviceName }}.</p>
-      <p class="govuk-body">If you think you should have an account, email us at <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">If you think you should have an account, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/error.njk" %}
 
+{% set hidePrimaryNavigation = true %}
+
 {% set title = "Ask for an account to " + (serviceName | lower) %}
 
 {% block content %}

--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -2,7 +2,7 @@
 
 {% set hidePrimaryNavigation = true %}
 
-{% set title = "Ask for an account to " + (serviceName | lower) %}
+{% set title = "Ask for an account to " + serviceName %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/error.njk" %}
+
+{% set title = "Ask for an account to " + (serviceName | lower) %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">Although you have a DfE Sign-in account, you also need an account on {{ serviceName }}.</p>
+      <p class="govuk-body">If you think you should have an account, email us at <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/unauthorised.njk
+++ b/app/views/errors/unauthorised.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/error.njk" %}
 
+{% set hidePrimaryNavigation = true %}
+
 {% set title = "Your account is not authorised" %}
 
 {% block content %}

--- a/app/views/errors/unauthorised.njk
+++ b/app/views/errors/unauthorised.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/error.njk" %}
+
+{% set title = "Your account is not authorised" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You are seeing this page because you have signed into {{ serviceName }} but your account is not authorised to view this page.</p>
+      <p class="govuk-body">If you think your account should be authorised, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/unauthorised.njk
+++ b/app/views/errors/unauthorised.njk
@@ -9,7 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
       <p class="govuk-body">You are seeing this page because you have signed into {{ serviceName }} but your account is not authorised to view this page.</p>
-      <p class="govuk-body">If you think your account should be authorised, email <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a>.</p>
+      <p class="govuk-body">If you think your account should be authorised, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/layouts/error.njk
+++ b/app/views/layouts/error.njk
@@ -1,0 +1,26 @@
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% block pageTitle -%}
+  {{ subtitle + " - " if subtitle }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{%- endblock %}
+
+{% block head %}
+  {% include "_includes/head.njk" %}
+{% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    productName: serviceName,
+    containerClasses: "govuk-width-container",
+    navigationClasses: "govuk-header__navigation--end"
+  }) }}
+
+  {% if not hidePhaseBanner %}
+    {% include "_includes/phase-banner.njk" %}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+  {% include "_includes/footer.njk" %}
+{% endblock %}


### PR DESCRIPTION
This PR adds error pages for:

- [page not found (404)](https://register-providers-pr-45.herokuapp.com/404)
- [there is a problem with the service (500)](https://register-providers-pr-45.herokuapp.com/500)
- [service unavailable (503)](https://register-providers-pr-45.herokuapp.com/503)
- [account not recognised](https://register-providers-pr-45.herokuapp.com/account-not-recognised)
- [account not linked to an organisation](https://register-providers-pr-45.herokuapp.com/account-no-organisation)
- [account not authorised](https://register-providers-pr-45.herokuapp.com/account-not-recognised)