### PR TITLE
Add footer links and get help section

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/app/views/_components/footer/_footer.scss
+++ b/app/views/_components/footer/_footer.scss
@@ -1,0 +1,13 @@
+.app-footer {
+  .govuk-footer__meta-custom {
+    max-width: 40rem;
+  }
+
+  .govuk-footer__inline-list {
+    margin-bottom: 0;
+  }
+
+  .govuk-footer__inline-list-item {
+    margin-bottom: 0;
+  }
+}

--- a/app/views/_components/footer/macro.njk
+++ b/app/views/_components/footer/macro.njk
@@ -1,0 +1,3 @@
+{% macro appFooter(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/footer/template.njk
+++ b/app/views/_components/footer/template.njk
@@ -1,0 +1,71 @@
+{#
+  Extends and modifies the footer component from GOV.UK Frontend by:
+    * Removing licensing information
+    * Providing params.meta.title (shows params.meta.visuallyHiddenTitle if not set)
+    * Moving meta.text/meta.html above meta.items
+#}
+<footer class="govuk-footer app-footer {{- ' ' +  params.classes if params.classes }}" role="contentinfo"
+        {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <div class="govuk-width-container {{- ' ' + params.containerClasses if params.containerClasses }}">
+    {% if params.navigation %}
+      <div class="govuk-footer__navigation">
+        {% for nav in params.navigation %}
+          <div class="govuk-footer__section">
+            <h2 class="govuk-footer__heading govuk-heading-m">{{ nav.title }}</h2>
+            {% if nav.items %}
+              {% set listClasses %}
+                {% if nav.columns %}
+                  govuk-footer__list--columns-{{ nav.columns }}
+                {% endif %}
+              {% endset %}
+              <ul class="govuk-footer__list {{ listClasses | trim }}">
+                {% for item in nav.items %}
+                  {% if item.href and item.text %}
+                    <li class="govuk-footer__list-item">
+                      <a class="govuk-footer__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                        {{ item.text }}
+                      </a>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
+      <hr class="govuk-footer__section-break">
+    {% endif %}
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        {% if params.meta %}
+          {% if params.meta.title %}
+            <h2 class="govuk-heading-m">{{ params.meta.title }}</h2>
+          {% else %}
+            <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links") }}</h2>
+          {% endif %}
+          {% if params.meta.text or params.meta.html %}
+            <div class="govuk-footer__meta-custom">
+              {{ params.meta.html | safe if params.meta.html else params.meta.text }}
+            </div>
+          {% endif %}
+          {% if params.meta.items %}
+            <ul class="govuk-footer__inline-list">
+              {% for item in params.meta.items %}
+                <li class="govuk-footer__inline-list-item">
+                  <a class="govuk-footer__link" href="{{ item.href }}" {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+                    {{ item.text }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endif %}
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/_components/index.scss
+++ b/app/views/_components/index.scss
@@ -1,4 +1,5 @@
 @import "checkbox-filter/checkbox-filter";
 @import "filter/filter";
+@import "footer/footer";
 @import "search/search";
 @import "secondary-navigation/secondary-navigation";

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -17,7 +17,6 @@
 {% endset %}
 
 {{ appFooter({
-  classes: "app-footer",
   meta: {
     title: "Get help",
     html: helpHtml,

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -5,12 +5,12 @@
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
         Email
       </h3>
-      <p class="govuk-body govuk-!-margin-bottom-1">
+      <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <a class="govuk-footer__link" href="mailto:ittmentor.funding@education.gov.uk">
           becomingateacher@education.gov.uk
         </a>
       </p>
-      <p class="govuk-body">You’ll get a response within 5 working days.</p>
+      <p class="govuk-!-font-size-16">You’ll get a response within 5 working days.</p>
     </div>
   </div>
 </div>
@@ -22,20 +22,20 @@
     title: "Get help",
     html: helpHtml,
     items: [{
-      href: "/guidance",
+      href: "#",
       text: "How to use this service"
     }, {
-      href: "/accessibility",
+      href: "#",
       text: "Accessibility"
     }, {
-      href: "/cookies",
+      href: "#",
       text: "Cookies"
     }, {
-      href: "/privacy",
+      href: "#",
       text: "Privacy notice"
     }, {
-      href: "/terms",
+      href: "#",
       text: "Terms and conditions"
-    }] if not hideFooterLinks and 1==0
+    }] if not hideFooterLinks
   }
 }) }}

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -1,1 +1,41 @@
-{{ govukFooter({}) }}
+{% set helpHtml %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-footer__email">
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+        Email
+      </h3>
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <a class="govuk-footer__link" href="mailto:ittmentor.funding@education.gov.uk">
+          becomingateacher@education.gov.uk
+        </a>
+      </p>
+      <p class="govuk-body">You’ll get a response within 5 working days.</p>
+    </div>
+  </div>
+</div>
+{% endset %}
+
+{{ appFooter({
+  classes: "app-footer",
+  meta: {
+    title: "Get help",
+    html: helpHtml,
+    items: [{
+      href: "/guidance",
+      text: "How to use this service"
+    }, {
+      href: "/accessibility",
+      text: "Accessibility"
+    }, {
+      href: "/cookies",
+      text: "Cookies"
+    }, {
+      href: "/privacy",
+      text: "Privacy notice"
+    }, {
+      href: "/terms",
+      text: "Terms and conditions"
+    }] if not hideFooterLinks and 1==0
+  }
+}) }}

--- a/app/views/_includes/footer.njk
+++ b/app/views/_includes/footer.njk
@@ -7,7 +7,7 @@
       </h3>
       <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
         <a class="govuk-footer__link" href="mailto:ittmentor.funding@education.gov.uk">
-          becomingateacher@education.gov.uk
+          becomingateacher@digital.education.gov.uk
         </a>
       </p>
       <p class="govuk-!-font-size-16">You’ll get a response within 5 working days.</p>

--- a/app/views/layouts/main.njk
+++ b/app/views/layouts/main.njk
@@ -1,6 +1,7 @@
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
 {% from "_components/checkbox-filter/macro.njk" import appCheckboxFilter %}
+{% from "_components/footer/macro.njk" import appFooter %}
 {% from "_components/search/macro.njk" import appSearch %}
 {% from "_components/secondary-navigation/macro.njk" import appSecondaryNavigation %}
 


### PR DESCRIPTION
This PR adds the following to the footer:

- get help section
- links
  - how to use this service
  - accessibility
  - cookies
  - privacy policy
  - terms and conditions

It also removes the 'Open Government Licence v3.0' information since it is irrelevant.

This PR does not add content pages for each footer link.