### PR TITLE
Add simple 'Your account' section

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,0 +1,7 @@
+const { User } = require('../models')
+
+exports.userAccount = async (req, res) => {
+  const { user } = req.session.passport
+  const accountUser = await User.findByPk(user.id)
+  res.render('account/show', { user: accountUser })
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -28,6 +28,7 @@ const passport = {
 /// ------------------------------------------------------------------------ ///
 /// Controller modules
 /// ------------------------------------------------------------------------ ///
+const accountController = require('./controllers/account')
 const errorController = require('./controllers/error')
 const feedbackController = require('./controllers/feedback')
 const providerController = require('./controllers/provider')
@@ -233,6 +234,12 @@ router.post('/providers/:providerId/restore', checkIsAuthenticated, providerCont
 router.get('/providers/:providerId', checkIsAuthenticated, providerController.providerDetails)
 
 router.get('/providers', checkIsAuthenticated, providerController.providersList)
+
+/// ------------------------------------------------------------------------ ///
+/// MY ACCOUNT ROUTES
+/// ------------------------------------------------------------------------ ///
+
+router.get('/account', checkIsAuthenticated, accountController.userAccount)
 
 /// ------------------------------------------------------------------------ ///
 /// FEEDBACK ROUTES

--- a/app/views/account/show.njk
+++ b/app/views/account/show.njk
@@ -1,0 +1,60 @@
+{% extends "layouts/auth.njk" %}
+
+{% set headerNavId = "account" %}
+
+{% set hidePrimaryNavigation = true %}
+{% set hideOrganisationSwitcher = true %}
+
+{% set title = "Your account" %}
+
+{% block beforeContent %}
+{{ govukBreadcrumbs({
+  items: [{
+    text: "Home",
+    href: "/"
+  }]
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "First name"
+            },
+            value: {
+              text: user.firstName
+            }
+          },
+          {
+            key: {
+              text: "Last name"
+            },
+            value: {
+              text: user.lastName
+            }
+          },
+          {
+            key: {
+              text: "Email address"
+            },
+            value: {
+              text: user.email
+            }
+          }
+        ]
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR introduces a simple 'Your account' section replaying the user's details. Users access the section via the header's 'Your account' link.

We don't include change links since users manage their accounts via DfE Sign-in.