### PR TITLE
Update how we delete users

### DIFF
--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -16,6 +16,7 @@ exports.usersList = async (req, res) => {
 
   // Only fetch ONE page of users
   const users = await User.findAll({
+    where: { 'deletedAt': null },
     order: [['firstName', 'ASC'],['lastName', 'ASC']],
     limit,
     offset
@@ -293,21 +294,26 @@ exports.editUserCheck_post = async (req, res) => {
 
 exports.deleteUser_get = async (req, res) => {
   const { userId } = req.params
-  const user = await User.findOne({ where: { id: userId } })
+  const user = await User.findByPk(userId)
   res.render('users/delete', {
     user,
     actions: {
-      back: `/users/${userId}/edit`,
-      cancel: `/users/${userId}`
+      back: `/users/${userId}`,
+      cancel: `/users/${userId}`,
+      delete: `/users/${userId}/delete`
     }
   })
 }
 
 exports.deleteUser_post = async (req, res) => {
   const { userId } = req.params
-  const user = await User.findOne({ where: { id: userId } })
-  user.destroy()
+  const user = await User.findByPk(userId)
+  await user.update({
+    deletedAt: new Date(),
+    deletedById: req.session.passport.user.id,
+    updatedById: req.session.passport.user.id
+  })
 
-  req.flash('success', 'Support user removed')
+  req.flash('success', 'Support user deleted')
   res.redirect('/users')
 }

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -47,7 +47,14 @@ exports.usersList = async (req, res) => {
 
 exports.userDetails = async (req, res) => {
   const user = await User.findOne({ where: { id: req.params.userId } })
-  res.render('users/show', { user })
+  res.render('users/show', {
+    user,
+    actions: {
+      back: '/users',
+      change: `/users/${user.id}/edit`,
+      delete: `/users/${user.id}/delete`
+    }
+  })
 }
 
 exports.newUser_get = async (req, res) => {
@@ -284,7 +291,13 @@ exports.editUserCheck_post = async (req, res) => {
 exports.deleteUser_get = async (req, res) => {
   const { userId } = req.params
   const user = await User.findOne({ where: { id: userId } })
-  res.render('users/delete', { user })
+  res.render('users/delete', {
+    user,
+    actions: {
+      back: `/users/${userId}/edit`,
+      cancel: `/users/${userId}`
+    }
+  })
 }
 
 exports.deleteUser_post = async (req, res) => {

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -97,7 +97,14 @@ exports.newUser_post = async (req, res) => {
     errors.push(error)
   }
 
-  const userCount = await User.count({ where: { email: user.email } })
+  const whereClause = {
+    [Op.and]: [
+      { email: user.email },
+      { deletedAt: null }
+    ]
+  }
+
+  const userCount = await User.count({ where: whereClause })
 
   const isValidEmailAddress = !!(
     isValidEmail(user.email) &&

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -14,7 +14,7 @@ exports.usersList = async (req, res) => {
   const offset = (page - 1) * limit
 
   // Get the total number of providers for pagination metadata
-  const totalCount = await User.count()
+  const totalCount = await User.count({ where: { deletedAt: null } })
 
   // Only fetch ONE page of users
   const users = await User.findAll({

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -166,7 +166,7 @@ exports.newUserCheck_post = async (req, res) => {
 
 exports.editUser_get = async (req, res) => {
   const { userId } = req.params
-  const currentUser = await User.findOne({ where: { id: userId } })
+  const currentUser = await User.findByPk(userId)
 
   let user
   if (req.session.data.user) {
@@ -189,7 +189,7 @@ exports.editUser_get = async (req, res) => {
 exports.editUser_post = async (req, res) => {
   const { userId } = req.params
   const { user } = req.session.data
-  const currentUser = await User.findOne({ where: { id: userId } })
+  const currentUser = await User.findByPk(userId)
   const errors = []
 
   if (!user.firstName.length) {
@@ -260,7 +260,7 @@ exports.editUserCheck_get = async (req, res) => {
   const { userId } = req.params
   const { user } = req.session.data
 
-  const currentUser = await User.findOne({ where: { id: userId } })
+  const currentUser = await User.findByPk(userId)
 
   res.render('users/check-your-answers', {
     currentUser,
@@ -277,7 +277,7 @@ exports.editUserCheck_get = async (req, res) => {
 exports.editUserCheck_post = async (req, res) => {
   const { userId } = req.params
   const { user } = req.session.data
-  const currentUser = await User.findOne({ where: { id: userId } })
+  const currentUser = await User.findByPk(userId)
 
   currentUser.update({
     firstName: user.firstName,

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -47,8 +47,11 @@ exports.usersList = async (req, res) => {
 
 exports.userDetails = async (req, res) => {
   const user = await User.findOne({ where: { id: req.params.userId } })
+  const showDeleteLink = !(req.params.userId === req.session.passport.user.id)
+
   res.render('users/show', {
     user,
+    showDeleteLink,
     actions: {
       back: '/users',
       change: `/users/${user.id}/edit`,

--- a/app/migrations/20250123141732-create-user.js
+++ b/app/migrations/20250123141732-create-user.js
@@ -44,6 +44,12 @@ module.exports = {
       updated_by_id: {
         type: Sequelize.UUID,
         allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
       }
     })
   },

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class User extends Model {
@@ -16,7 +15,7 @@ module.exports = (sequelize) => {
   User.init({
     id: {
       type: DataTypes.UUID,
-      defaultValue: uuid(),
+      defaultValue: DataTypes.UUIDV4,
       allowNull: false,
       primaryKey: true
     },
@@ -39,7 +38,6 @@ module.exports = (sequelize) => {
     email: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true,
       validate: {
         notEmpty: true,
         isEmail: true

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -74,6 +74,14 @@ module.exports = (sequelize) => {
       type: DataTypes.UUID,
       allowNull: false,
       field: 'updated_by_id'
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      field: 'deleted_at'
+    },
+    deletedById: {
+      type: DataTypes.UUID,
+      field: 'deleted_by_id'
     }
   },
   {

--- a/app/views/users/delete.njk
+++ b/app/views/users/delete.njk
@@ -2,13 +2,13 @@
 
 {% set primaryNavId = "users" %}
 
-{% set title = "Confirm you want to remove " + user.firstName + " " + user.lastName + "?" %}
-{% set caption = "Remove support user" %}
+{% set title = "Confirm you want to delete " + user.firstName + " " + user.lastName %}
+{% set caption = "Delete user" %}
 
 {% block beforeContent %}
 {{ govukBackLink({
   text: "Back",
-  href: "/users/" + user.id
+  href: actions.back
 }) }}
 {% endblock %}
 
@@ -22,17 +22,22 @@
       {{ title }}
     </h1>
 
-    <form action="/users/{{ user.id }}/delete" method="post" accept-charset="utf-8" novalidate>
+    <form action="{{ actions.delete }}" method="post" accept-charset="utf-8" novalidate>
+
+      {{ govukWarningText({
+        text: "Deleting a user is permanent – you cannot undo it.",
+        iconFallbackText: "Warning"
+      }) }}
 
       {{ govukButton({
-        text: "Remove user",
+        text: "Delete user",
         classes: "govuk-button--warning"
       }) }}
 
     </form>
 
     <p class="govuk-body">
-      <a class="govuk-link" href="/users/{{ user.id }}">Cancel</a>
+      <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
     </p>
 
   </div>

--- a/app/views/users/show.njk
+++ b/app/views/users/show.njk
@@ -25,7 +25,7 @@
     </h1>
 
     <p class="govuk-body">
-      <a href="/users/{{ user.id }}/delete" class="govuk-link">Remove user</a>
+      <a href="{{ actions.delete }}" class="govuk-link">Delete user</a>
     </p>
 
     {{ govukSummaryList({
@@ -40,7 +40,7 @@
           actions: {
             items: [
               {
-                href: "/users/" + user.id + "/edit",
+                href: actions.change,
                 text: "Change",
                 visuallyHiddenText: "first name"
               }
@@ -57,7 +57,7 @@
           actions: {
             items: [
               {
-                href: "/users/" + user.id + "/edit",
+                href: actions.change,
                 text: "Change",
                 visuallyHiddenText: "last name"
               }
@@ -74,7 +74,7 @@
           actions: {
             items: [
               {
-                href: "/users/" + user.id + "/edit",
+                href: actions.change,
                 text: "Change",
                 visuallyHiddenText: "email"
               }

--- a/app/views/users/show.njk
+++ b/app/views/users/show.njk
@@ -24,9 +24,12 @@
       {{ title }}
     </h1>
 
-    <p class="govuk-body">
-      <a href="{{ actions.delete }}" class="govuk-link">Delete user</a>
-    </p>
+    {# only show delete link if it's not the signed in user #}
+    {% if showDeleteLink %}
+      <p class="govuk-body">
+        <a href="{{ actions.delete }}" class="govuk-link">Delete user</a>
+      </p>
+    {% endif %}
 
     {{ govukSummaryList({
       rows: [


### PR DESCRIPTION
This PR:

- updates the delete flow to soft delete users (i.e., they remain in the database)
- prevents users from deleting themselves from the service
- prevents users from adding new users with the same email address as another user

Update: This PR does not address personally identifiable information (PII) in the page titles. That will be completed in a separate piece of work.