### PR TITLE
Use DataTypes.UUIDV4 as default ID value

### DIFF
--- a/app/models/provider.js
+++ b/app/models/provider.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class Provider extends Model {
@@ -54,7 +53,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       operatingName: {

--- a/app/models/providerAccreditation.js
+++ b/app/models/providerAccreditation.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class ProviderAccreditation extends Model {
@@ -25,7 +24,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       providerId: {

--- a/app/models/providerAddress.js
+++ b/app/models/providerAddress.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class ProviderAddress extends Model {
@@ -25,7 +24,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       providerId: {

--- a/app/models/providerContact.js
+++ b/app/models/providerContact.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class ProviderContact extends Model {
@@ -25,7 +24,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       providerId: {

--- a/app/models/providerHistory.js
+++ b/app/models/providerHistory.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class ProviderHistory extends Model {
@@ -25,7 +24,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       providerId: {

--- a/app/models/providerPartnership.js
+++ b/app/models/providerPartnership.js
@@ -1,5 +1,4 @@
 const { Model, DataTypes } = require('sequelize')
-const { v4: uuid } = require('uuid')
 
 module.exports = (sequelize) => {
   class ProviderPartnership extends Model {
@@ -30,7 +29,7 @@ module.exports = (sequelize) => {
     {
       id: {
         type: DataTypes.UUID,
-        defaultValue: uuid(),
+        defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
       trainingProviderId: {


### PR DESCRIPTION
This PR replaces `uuid()` as the default value for the ID field and uses the inbuilt `DataTypes.UUIDV4`. This tells Sequelize to generate a fresh UUID automatically every time a new record is inserted into the database.