### PR TITLE
Remove personally identifiable information from page titles

### DIFF
--- a/app/views/users/delete.njk
+++ b/app/views/users/delete.njk
@@ -2,6 +2,10 @@
 
 {% set primaryNavId = "users" %}
 
+{% block pageTitle -%}
+  Confirm you want to delete support user - {{ serviceName }} - GOV.UK
+{%- endblock %}
+
 {% set title = "Confirm you want to delete " + user.firstName + " " + user.lastName %}
 {% set caption = "Delete support user" %}
 
@@ -17,10 +21,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">{{ caption }}</span>
-      {{ title }}
-    </h1>
+    {% include "_includes/page-heading.njk" %}
 
     <form action="{{ actions.delete }}" method="post" accept-charset="utf-8" novalidate>
 

--- a/app/views/users/edit.njk
+++ b/app/views/users/edit.njk
@@ -2,6 +2,10 @@
 
 {% set primaryNavId = "users" %}
 
+{% block pageTitle -%}
+  {{ "Error: " if errors.length -}} Change support user personal details - {{ serviceName }} - GOV.UK
+{%- endblock %}
+
 {% set title = "Personal details" %}
 
 {% if currentUser %}
@@ -9,10 +13,6 @@
 {% else %}
   {% set caption = "Add support user" %}
 {% endif %}
-
-{% block pageTitle %}
-  {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
-{% endblock %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -29,17 +29,16 @@
   <div class="govuk-grid-column-two-thirds">
 
     {% set headingHtml %}
-      <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">{{ caption }}</span>
-        {{ title }}
-      </h1>
+      {% include "_includes/page-heading-legend.njk" %}
     {% endset %}
 
     <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
       {% call govukFieldset({
         legend: {
-          html: headingHtml
+          html: headingHtml,
+          classes: "govuk-fieldset__legend--l",
+          isPageHeading: true
         }
       }) %}
 

--- a/app/views/users/show.njk
+++ b/app/views/users/show.njk
@@ -2,6 +2,10 @@
 
 {% set primaryNavId = "users" %}
 
+{% block pageTitle -%}
+  View support user - {{ serviceName }} - GOV.UK
+{%- endblock %}
+
 {% set title = user.firstName + " " + user.lastName %}
 {% set caption = "Support user" %}
 
@@ -19,10 +23,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">{{ caption }}</span>
-      {{ title }}
-    </h1>
+    {% include "_includes/page-heading.njk" %}
 
     {# only show delete link if it's not the signed in user #}
     {% if showDeleteLink %}


### PR DESCRIPTION
This PR removes personally identifiable information from page titles (i.e., the `<title>` tag).

Pages included in this change:

- view support user's details
- change support user's details
- delete support user

The provider contacts section does not need to change as we do not show PII in the page title.