### PR TITLE
Prevent duplicate partnerships

### DIFF
--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -1,7 +1,7 @@
-const { Op } = require('sequelize')
 const { Provider, ProviderPartnership } = require('../models')
 const Pagination = require('../helpers/pagination')
 const { isAccreditedProvider } = require('../helpers/accreditation')
+const { hasPartnership } = require('../helpers/partnership')
 
 /// ------------------------------------------------------------------------ ///
 /// List provider partnerships
@@ -185,8 +185,44 @@ exports.newProviderPartnership_post = async (req, res) => {
       }
     })
   } else {
-    res.redirect(`/providers/${providerId}/partnerships/new/check`)
+
+    let hasExistingPartnership
+    if (isAccredited) {
+      hasExistingPartnership = await hasPartnership({
+        accreditedProviderId: providerId,
+        trainingProviderId: req.session.data.provider.id
+      })
+    } else {
+      hasExistingPartnership = await hasPartnership({
+        accreditedProviderId: req.session.data.provider.id,
+        trainingProviderId: providerId
+      })
+    }
+
+    if (hasExistingPartnership) {
+      res.redirect(`/providers/${providerId}/partnerships/new/duplicate`)
+    } else {
+      res.redirect(`/providers/${providerId}/partnerships/new/check`)
+    }
   }
+}
+
+exports.newProviderPartnershipDuplicate_get = async (req, res) => {
+  // get the provider and partnership IDs from the request
+  const { providerId } = req.params
+  const provider = await Provider.findByPk(providerId)
+
+  const partner = await Provider.findByPk(req.session.data.provider.id)
+
+  res.render('providers/partnerships/duplicate', {
+    provider,
+    partner,
+    actions: {
+      back: `/providers/${providerId}/partnerships/new`,
+      cancel: `/providers/${providerId}/partnerships`,
+      change: `/providers/${providerId}/partnerships/new`
+    }
+  })
 }
 
 exports.newProviderPartnershipCheck_get = async (req, res) => {

--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -54,6 +54,7 @@ exports.providerPartnershipsList = async (req, res) => {
 
   // Clear session provider data
   delete req.session.data.partnership
+  delete req.session.data.search
 
   res.render('providers/partnerships/index', {
     provider,
@@ -159,7 +160,11 @@ exports.newProviderPartnership_post = async (req, res) => {
     const error = {}
     error.fieldName = "provider-autocomplete"
     error.href = "#provider-autocomplete"
-    error.text = "Enter provider name, UKPRN, URN or postcode"
+    if (isAccredited) {
+      error.text = "Enter training partner name, UKPRN or URN"
+    } else {
+      error.text = "Enter accredited provider name, UKPRN or URN"
+    }
     errors.push(error)
   }
 

--- a/app/helpers/partnership.js
+++ b/app/helpers/partnership.js
@@ -1,0 +1,16 @@
+const { ProviderPartnership } = require('../models')
+
+const hasPartnership = async (params) => {
+  const partnershipCount = await ProviderPartnership.count({
+    where: {
+      accreditedProviderId: params.accreditedProviderId,
+      trainingProviderId: params.trainingProviderId
+    }
+  })
+
+  return !!partnershipCount
+}
+
+module.exports = {
+  hasPartnership
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -178,6 +178,8 @@ router.get('/providers/:providerId/addresses', checkIsAuthenticated, providerAdd
 router.get('/providers/:providerId/partnerships/new', checkIsAuthenticated, providerPartnershipController.newProviderPartnership_get)
 router.post('/providers/:providerId/partnerships/new', checkIsAuthenticated, providerPartnershipController.newProviderPartnership_post)
 
+router.get('/providers/:providerId/partnerships/new/duplicate', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipDuplicate_get)
+
 router.get('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_get)
 router.post('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_post)
 

--- a/app/views/providers/partnerships/delete.njk
+++ b/app/views/providers/partnerships/delete.njk
@@ -8,8 +8,8 @@
   {% set partner = partnership.accreditedProvider %}
 {% endif %}
 
-{% set title = "Confirm you want to remove " + provider.operatingName + "’s partnership with " + partner.operatingName %}
-{% set caption = "Remove partnership" %}
+{% set title = "Confirm you want to remove partnership with " + partner.operatingName %}
+{% set caption = "Remove partnership - " + provider.operatingName %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -26,6 +26,11 @@
     {% include "_includes/page-heading.njk" %}
 
     <form action="{{ actions.delete }}" method="post" accept-charset="utf-8" novalidate>
+
+      {# {{ govukWarningText({
+        text: "Removing a partnership is permanent – you cannot undo it.",
+        iconFallbackText: "Warning"
+      }) }} #}
 
       {{ govukButton({
         text: "Remove partnership",

--- a/app/views/providers/partnerships/duplicate.njk
+++ b/app/views/providers/partnerships/duplicate.njk
@@ -1,0 +1,36 @@
+{% extends "layouts/main.njk" %}
+
+{% set primaryNavId = "providers" %}
+
+{% set title = "You cannot add the partnership" %}
+{% set caption = "Add partnership - " + provider.operatingName %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {% include "_includes/page-heading.njk" %}
+
+    <p class="govuk-body">
+      You cannot add the partnership because {{ partner.operatingName }} is already a partner of {{ provider.operatingName }}.
+    </p>
+
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ actions.change }}">Change your search</a>
+    </p>
+
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+    </p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/providers/partnerships/find.njk
+++ b/app/views/providers/partnerships/find.njk
@@ -2,7 +2,11 @@
 
 {% set primaryNavId = "providers" %}
 
-{% set title = "Enter a provider name, UKPRN, URN or postcode" %}
+{% if isAccredited %}
+  {% set title = "Enter training partner name, UKPRN or URN" %}
+{% else %}
+  {% set title = "Enter accredited provider name, UKPRN or URN" %}
+{% endif %}
 
 {% if currentPartnership %}
   {% set caption = provider.operatingName %}
@@ -36,7 +40,7 @@
       {# Hidden field to store the provider ID #}
       <input type="hidden" id="selected-provider-id" name="provider[id]" value="{{ data.provider.id | default('') }}">
 
-      <div class="govuk-form-group {{- ' govuk-form-group--error' if (errors | getErrorMessage('provider'))}}">
+      <div class="govuk-form-group {{- ' govuk-form-group--error' if errors.length }}">
         <label class="govuk-label govuk-label--l" for="provider-autocomplete">
           <span class="govuk-caption-l">{{ caption }} </span>
           {{ title }}
@@ -46,21 +50,12 @@
 
       {% set helpText %}
         <p class="govuk-body">
-          {# If you cannot find the provider, it may be because the provider: #}
           Something helpful goes here
         </p>
-        {# <ul class="govuk-list govuk-list--bullet">
-          <li>
-            is not a training provider
-          </li>
-          <li>
-            has not been added to the service
-          </li>
-        </ul> #}
       {% endset %}
 
       {{ govukDetails({
-        summaryText: "I cannot find the provider",
+        summaryText: "I cannot find the " + ("training partner" if isAccredited else "accredited provider"),
         html: helpText
       }) }}
 


### PR DESCRIPTION
This PR introduces functionality to prevent users from adding duplicate partnerships. If the user attempts to add a partner that already exists, we display a page that prevents them from completing the process.

The flow:

- view a provider
- go to the partnerships tab
- add a provider already in the provider's list of partnerships
- view message

For example:

![Screenshot 2025-04-29 at 16 42 42@2x](https://github.com/user-attachments/assets/f3780a9f-5818-458b-97f3-2bc45a00ef2c)
