### PR TITLE
Create 'provider accreditation revisions' functionality

### DIFF
--- a/app/constants/revisionFields.js
+++ b/app/constants/revisionFields.js
@@ -11,5 +11,12 @@ module.exports = {
     'archivedById',
     'deletedAt',
     'deletedById'
+  ],
+  providerAccreditation: [
+    'number',
+    'startsOn',
+    'endsOn',
+    'deletedAt',
+    'deletedById'
   ]
 }

--- a/app/controllers/providerAccreditation.js
+++ b/app/controllers/providerAccreditation.js
@@ -23,12 +23,18 @@ exports.providerAccreditationsList = async (req, res) => {
 
   // Get the total number of accreditations for pagination metadata
   const totalCount = await ProviderAccreditation.count({
-    where: { providerId }
+    where: {
+      providerId,
+      deletedAt: null
+    }
   })
 
   // Only fetch ONE page of accreditations
   const accreditations = await ProviderAccreditation.findAll({
-    where: { providerId },
+    where: {
+      providerId,
+      deletedAt: null
+    },
     order: [['id', 'ASC']],
     limit,
     offset
@@ -343,9 +349,14 @@ exports.deleteProviderAccreditation_get = async (req, res) => {
 
 exports.deleteProviderAccreditation_post = async (req, res) => {
   const { accreditationId, providerId } = req.params
+  const { user } = req.session.passport
   const accreditation = await ProviderAccreditation.findByPk(accreditationId)
-  await accreditation.destroy()
+  await accreditation.update({
+    deletedAt: new Date(),
+    deletedById: user.id,
+    updatedById: user.id
+  })
 
-  req.flash('success', 'Accreditation removed')
+  req.flash('success', 'Accreditation deleted')
   res.redirect(`/providers/${providerId}/accreditations`)
 }

--- a/app/migrations/20250128150700-create-provider-accreditation.js
+++ b/app/migrations/20250128150700-create-provider-accreditation.js
@@ -37,6 +37,12 @@ module.exports = {
       updated_by_id: {
         type: Sequelize.UUID,
         allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
       }
     })
   },

--- a/app/migrations/20250508161900-create-provider-accreditation-revision.js
+++ b/app/migrations/20250508161900-create-provider-accreditation-revision.js
@@ -1,0 +1,77 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('provider_accreditation_revisions', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      provider_accreditation_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'provider_accreditations',
+          key: 'id'
+        }
+      },
+      provider_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'providers',
+          key: 'id'
+        }
+      },
+      number: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      starts_on: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      ends_on: {
+        type: Sequelize.DATE
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      created_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
+      },
+      revision_number: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      revision_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      revision_by_id: {
+        type: Sequelize.UUID,
+        allowNull: true
+      }
+    })
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('provider_accreditation_revisions')
+  }
+}

--- a/app/models/provider.js
+++ b/app/models/provider.js
@@ -157,6 +157,5 @@ module.exports = (sequelize) => {
     createRevisionHook({ revisionModelName: 'ProviderRevision', modelKey: 'provider' })
   )
 
-
   return Provider
 }

--- a/app/models/providerAccreditation.js
+++ b/app/models/providerAccreditation.js
@@ -64,6 +64,14 @@ module.exports = (sequelize) => {
         type: DataTypes.UUID,
         allowNull: false,
         field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
       }
     },
     {
@@ -72,6 +80,19 @@ module.exports = (sequelize) => {
       tableName: 'provider_accreditations',
       timestamps: true
     }
+  )
+
+  const createRevisionHook = require('../hooks/revisionHook')
+
+  ProviderAccreditation.addHook('afterCreate', (instance, options) =>
+    createRevisionHook({ revisionModelName: 'ProviderAccreditationRevision', modelKey: 'providerAccreditation' })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
+  ProviderAccreditation.addHook('afterUpdate',
+    createRevisionHook({ revisionModelName: 'ProviderAccreditationRevision', modelKey: 'providerAccreditation' })
   )
 
   return ProviderAccreditation

--- a/app/models/providerAccreditationRevision.js
+++ b/app/models/providerAccreditationRevision.js
@@ -1,0 +1,104 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class ProviderAccreditationRevision extends Model {
+    static associate(models) {
+      ProviderAccreditationRevision.belongsTo(models.ProviderAccreditation, {
+        foreignKey: 'providerAccreditationId',
+        as: 'providerAccreditation'
+      })
+
+      ProviderAccreditationRevision.belongsTo(models.Provider, {
+        foreignKey: 'providerId',
+        as: 'provider'
+      })
+
+      ProviderAccreditationRevision.belongsTo(models.User, {
+        foreignKey: 'revisionById',
+        as: 'revisionByUser'
+      })
+    }
+  }
+
+  ProviderAccreditationRevision.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true
+      },
+      providerAccreditationId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_accreditation_id'
+      },
+      providerId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_id'
+      },
+      number: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      startsOn: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'starts_on'
+      },
+      endsOn: {
+        type: DataTypes.DATE,
+        field: 'ends_on'
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      },
+      revisionNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'revision_number'
+      },
+      revisionAt: {
+        type: DataTypes.DATE,
+        field: 'revision_at'
+      },
+      revisionById: {
+        type: DataTypes.UUID,
+        field: 'revision_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'ProviderAccreditationRevision',
+      tableName: 'provider_accreditation_revisions',
+      timestamps: false
+    }
+  )
+
+  return ProviderAccreditationRevision
+}

--- a/app/views/providers/accreditations/delete.njk
+++ b/app/views/providers/accreditations/delete.njk
@@ -2,8 +2,8 @@
 
 {% set primaryNavId = "providers" %}
 
-{% set title = "Confirm you want to remove " + provider.operatingName + "’s accreditation" %}
-{% set caption = "Remove accreditation" %}
+{% set title = "Confirm you want to delete " + provider.operatingName + "’s accreditation" %}
+{% set caption = "Delete accreditation" %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -44,15 +44,20 @@
               text: "Date accreditation ends"
             },
             value: {
-              text: accreditation.endsOn | isoDateFromDateInput | govukDate if accreditation.endsOn | isoDateFromDateInput != "Invalid DateTime" else "Not entered",
-              classes: "govuk-hint" if accreditation.endsOn | isoDateFromDateInput == "Invalid DateTime"
+              text: accreditation.endsOn | govukDate if accreditation.endsOn else "Not entered",
+              classes: "govuk-hint" if not accreditation.endsOn
             }
           }
         ]
       }) }}
 
+      {{ govukWarningText({
+        text: "Deleting an accreditation is permanent – you cannot undo it.",
+        iconFallbackText: "Warning"
+      }) }}
+
       {{ govukButton({
-        text: "Remove accreditation",
+        text: "Delete accreditation",
         classes: "govuk-button--warning"
       }) }}
 

--- a/app/views/providers/accreditations/index.njk
+++ b/app/views/providers/accreditations/index.njk
@@ -54,7 +54,7 @@
               items: [
                 {
                   href: actions.delete + "/" + accreditation.id + "/delete",
-                  text: "Remove",
+                  text: "Delete",
                   visuallyHiddenText: "accreditation " + loop.index
                 },
                 {


### PR DESCRIPTION
This PR:

- creates a `provider_accreditation_revisions` table/migration
- creates a `providerAccreditationRevision` model
- adds hooks to the `providerAccreditation` model to log create and update statements (we soft delete, so no need to track deletions)