### PR TITLE
Create 'provider address revisions' functionality

### DIFF
--- a/app/constants/revisionFields.js
+++ b/app/constants/revisionFields.js
@@ -18,5 +18,19 @@ module.exports = {
     'endsOn',
     'deletedAt',
     'deletedById'
+  ],
+  providerAddress: [
+    'uprn',
+    'line1',
+    'line2',
+    'line3',
+    'town',
+    'county',
+    'postcode',
+    'latitude',
+    'longitude',
+    'googlePlaceId',
+    'deletedAt',
+    'deletedById'
   ]
 }

--- a/app/controllers/providerAddress.js
+++ b/app/controllers/providerAddress.js
@@ -27,12 +27,18 @@ exports.providerAddressesList = async (req, res) => {
 
   // Get the total number of addresses for pagination metadata
   const totalCount = await ProviderAddress.count({
-    where: { providerId }
+    where: {
+      providerId,
+      'deletedAt': null
+    }
   })
 
   // Only fetch ONE page of addresses
   const addresses = await ProviderAddress.findAll({
-    where: { providerId },
+    where: {
+      providerId,
+      'deletedAt': null
+    },
     order: [['id', 'ASC']],
     limit,
     offset
@@ -525,9 +531,14 @@ exports.deleteProviderAddress_get = async (req, res) => {
 
 exports.deleteProviderAddress_post = async (req, res) => {
   const { addressId, providerId } = req.params
+  const { user } = req.session.passport
   const address = await ProviderAddress.findByPk(addressId)
-  await address.destroy()
+  await address.update({
+    deletedAt: new Date(),
+    deletedById: user.id,
+    updatedById: user.id
+  })
 
-  req.flash('success', 'Address removed')
+  req.flash('success', 'Address deleted')
   res.redirect(`/providers/${providerId}/addresses`)
 }

--- a/app/migrations/20250128162700-create-provider-address.js
+++ b/app/migrations/20250128162700-create-provider-address.js
@@ -59,6 +59,12 @@ module.exports = {
       updated_by_id: {
         type: Sequelize.UUID,
         allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
       }
     })
   },

--- a/app/migrations/20250509103203-create-provider-address-revision.js
+++ b/app/migrations/20250509103203-create-provider-address-revision.js
@@ -1,0 +1,99 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('provider_address_revisions', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      provider_address_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'provider_addresses',
+          key: 'id'
+        }
+      },
+      provider_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'providers',
+          key: 'id'
+        }
+      },
+      uprn: {
+        type: Sequelize.STRING
+      },
+      line_1:  {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      line_2: {
+        type: Sequelize.STRING
+      },
+      line_3: {
+        type: Sequelize.STRING
+      },
+      town:  {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      county: {
+        type: Sequelize.STRING
+      },
+      postcode:  {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      latitude: {
+        type: Sequelize.FLOAT
+      },
+      longitude: {
+        type: Sequelize.FLOAT
+      },
+      google_place_id: {
+        type: Sequelize.STRING
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      created_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
+      },
+      revision_number: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      revision_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      revision_by_id: {
+        type: Sequelize.UUID,
+        allowNull: true
+      }
+    })
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('provider_address_revisions')
+  }
+}

--- a/app/models/providerAddress.js
+++ b/app/models/providerAddress.js
@@ -96,6 +96,14 @@ module.exports = (sequelize) => {
         type: DataTypes.UUID,
         allowNull: false,
         field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
       }
     },
     {
@@ -104,6 +112,19 @@ module.exports = (sequelize) => {
       tableName: 'provider_addresses',
       timestamps: true
     }
+  )
+
+  const createRevisionHook = require('../hooks/revisionHook')
+
+  ProviderAddress.addHook('afterCreate', (instance, options) =>
+    createRevisionHook({ revisionModelName: 'ProviderAddressRevision', modelKey: 'providerAddress' })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
+  ProviderAddress.addHook('afterUpdate',
+    createRevisionHook({ revisionModelName: 'ProviderAddressRevision', modelKey: 'providerAddress' })
   )
 
   return ProviderAddress

--- a/app/models/providerAddressRevision.js
+++ b/app/models/providerAddressRevision.js
@@ -1,0 +1,136 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class ProviderAddressRevision extends Model {
+    static associate(models) {
+      ProviderAddressRevision.belongsTo(models.ProviderAddress, {
+        foreignKey: 'providerAddressId',
+        as: 'providerAddress'
+      })
+
+      ProviderAddressRevision.belongsTo(models.Provider, {
+        foreignKey: 'providerId',
+        as: 'provider'
+      })
+
+      ProviderAddressRevision.belongsTo(models.User, {
+        foreignKey: 'revisionById',
+        as: 'revisionByUser'
+      })
+    }
+  }
+
+  ProviderAddressRevision.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true
+      },
+      providerAddressId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_address_id'
+      },
+      providerId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_id'
+      },
+      uprn: {
+        type: DataTypes.STRING
+      },
+      line1:  {
+        type: DataTypes.STRING,
+        field: 'line_1',
+        validate: {
+          notEmpty: true
+        }
+      },
+      line2: {
+        type: DataTypes.STRING,
+        field: 'line_2'
+      },
+      line3: {
+        type: DataTypes.STRING,
+        field: 'line_3'
+      },
+      town:  {
+        type: DataTypes.STRING,
+        validate: {
+          notEmpty: true
+        }
+      },
+      county: {
+        type: DataTypes.STRING
+      },
+      postcode:  {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          is: /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/
+        }
+      },
+      latitude: {
+        type: DataTypes.FLOAT
+      },
+      longitude: {
+        type: DataTypes.FLOAT
+      },
+      googlePlaceId: {
+        type: DataTypes.STRING,
+        field: 'google_place_id'
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      },
+      revisionNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'revision_number'
+      },
+      revisionAt: {
+        type: DataTypes.DATE,
+        field: 'revision_at'
+      },
+      revisionById: {
+        type: DataTypes.UUID,
+        field: 'revision_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'ProviderAddressRevision',
+      tableName: 'provider_address_revisions',
+      timestamps: false
+    }
+  )
+
+  return ProviderAddressRevision
+}

--- a/app/views/providers/addresses/delete.njk
+++ b/app/views/providers/addresses/delete.njk
@@ -2,8 +2,8 @@
 
 {% set primaryNavId = "providers" %}
 
-{% set title = "Confirm you want to remove " + provider.operatingName + "’s address" %}
-{% set caption = "Remove address" %}
+{% set title = "Confirm you want to delete " + provider.operatingName + "’s address" %}
+{% set caption = "Delete address" %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -90,8 +90,13 @@
         ]
       }) }}
 
+      {{ govukWarningText({
+        text: "Deleting an address is permanent – you cannot undo it.",
+        iconFallbackText: "Warning"
+      }) }}
+
       {{ govukButton({
-        text: "Remove address",
+        text: "Delete address",
         classes: "govuk-button--warning"
       }) }}
 

--- a/app/views/providers/addresses/index.njk
+++ b/app/views/providers/addresses/index.njk
@@ -54,7 +54,7 @@
               items: [
                 {
                   href: actions.delete + "/" + address.id + "/delete",
-                  text: "Remove",
+                  text: "Delete",
                   visuallyHiddenText: "address " + loop.index
                 },
                 {


### PR DESCRIPTION
This PR:

- creates a `provider_address_revisions` table/migration
- creates a `providerAddressRevision` model
- adds hooks to the `providerAddress` model to log create and update statements (we soft delete, so no need to track deletions)
- changed action language from 'Remove' to 'Delete'