### PR TITLE
Create 'provider contact revisions' functionality

### DIFF
--- a/app/constants/revisionFields.js
+++ b/app/constants/revisionFields.js
@@ -32,5 +32,13 @@ module.exports = {
     'googlePlaceId',
     'deletedAt',
     'deletedById'
+  ],
+  providerContact: [
+    'firstName',
+    'lastName',
+    'email',
+    'telephone',
+    'deletedAt',
+    'deletedById'
   ]
 }

--- a/app/controllers/providerContact.js
+++ b/app/controllers/providerContact.js
@@ -23,12 +23,18 @@ exports.providerContactsList = async (req, res) => {
 
   // Get the total number of contacts for pagination metadata
   const totalCount = await ProviderContact.count({
-    where: { providerId }
+    where: {
+      providerId,
+      'deletedAt': null
+    }
   })
 
   // Only fetch ONE page of contacts
   const contacts = await ProviderContact.findAll({
-    where: { providerId },
+    where: {
+      providerId,
+      'deletedAt': null
+    },
     order: [['id', 'ASC']],
     limit,
     offset
@@ -351,9 +357,14 @@ exports.deleteProviderContact_get = async (req, res) => {
 
 exports.deleteProviderContact_post = async (req, res) => {
   const { contactId, providerId } = req.params
+  const { user } = req.session.passport
   const contact = await ProviderContact.findByPk(contactId)
-  await contact.destroy()
+  await contact.update({
+    deletedAt: new Date(),
+    deletedById: user.id,
+    updatedById: user.id
+  })
 
-  req.flash('success', 'Contact removed')
+  req.flash('success', 'Contact deleted')
   res.redirect(`/providers/${providerId}/contacts`)
 }

--- a/app/migrations/20250128150800-create-provider-contact.js
+++ b/app/migrations/20250128150800-create-provider-contact.js
@@ -42,6 +42,12 @@ module.exports = {
       updated_by_id: {
         type: Sequelize.UUID,
         allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
       }
     })
   },

--- a/app/migrations/20250509114718-create-provider-contact-revision.js
+++ b/app/migrations/20250509114718-create-provider-contact-revision.js
@@ -1,0 +1,82 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('provider_contact_revisions', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      provider_contact_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'provider_contacts',
+          key: 'id'
+        }
+      },
+      provider_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'providers',
+          key: 'id'
+        }
+      },
+      first_name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      last_name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      telephone: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      created_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
+      },
+      revision_number: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      revision_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      revision_by_id: {
+        type: Sequelize.UUID,
+        allowNull: true
+      }
+    })
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('provider_contact_revisions')
+  }
+}

--- a/app/models/providerContact.js
+++ b/app/models/providerContact.js
@@ -76,6 +76,14 @@ module.exports = (sequelize) => {
         type: DataTypes.UUID,
         allowNull: false,
         field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
       }
     },
     {
@@ -84,6 +92,19 @@ module.exports = (sequelize) => {
       tableName: 'provider_contacts',
       timestamps: true
     }
+  )
+
+  const createRevisionHook = require('../hooks/revisionHook')
+
+  ProviderContact.addHook('afterCreate', (instance, options) =>
+    createRevisionHook({ revisionModelName: 'ProviderContactRevision', modelKey: 'providerContact' })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
+  ProviderContact.addHook('afterUpdate',
+    createRevisionHook({ revisionModelName: 'ProviderContactRevision', modelKey: 'providerContact' })
   )
 
   return ProviderContact

--- a/app/models/providerContactRevision.js
+++ b/app/models/providerContactRevision.js
@@ -1,0 +1,116 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class ProviderContactRevision extends Model {
+    static associate(models) {
+      ProviderContactRevision.belongsTo(models.ProviderContact, {
+        foreignKey: 'providerContactId',
+        as: 'providerContact'
+      })
+
+      ProviderContactRevision.belongsTo(models.Provider, {
+        foreignKey: 'providerId',
+        as: 'provider'
+      })
+
+      ProviderContactRevision.belongsTo(models.User, {
+        foreignKey: 'revisionById',
+        as: 'revisionByUser'
+      })
+    }
+  }
+
+  ProviderContactRevision.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true
+      },
+      providerContactId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_contact_id'
+      },
+      providerId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'provider_id'
+      },
+      firstName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'first_name'
+      },
+      lastName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'last_name'
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          isEmail: true
+        }
+      },
+      telephone: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          is: /^(\+44\s?|0)(?:\d\s?){9,10}$/
+        }
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      },
+      revisionNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'revision_number'
+      },
+      revisionAt: {
+        type: DataTypes.DATE,
+        field: 'revision_at'
+      },
+      revisionById: {
+        type: DataTypes.UUID,
+        field: 'revision_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'ProviderContactRevision',
+      tableName: 'provider_contact_revisions',
+      timestamps: false
+    }
+  )
+
+  return ProviderContactRevision
+}

--- a/app/views/providers/contacts/delete.njk
+++ b/app/views/providers/contacts/delete.njk
@@ -3,11 +3,11 @@
 {% set primaryNavId = "providers" %}
 
 {% block pageTitle -%}
-  Confirm you want to remove provider contact - {{ provider.operatingName }} - {{ serviceName }} - GOV.UK
+  Confirm you want to delete provider contact - {{ provider.operatingName }} - {{ serviceName }} - GOV.UK
 {%- endblock %}
 
-{% set title = "Confirm you want to remove " + contact.firstName + " " + contact.lastName %}
-{% set caption = "Remove contact - " + provider.operatingName %}
+{% set title = "Confirm you want to delete " + contact.firstName + " " + contact.lastName %}
+{% set caption = "Delete contact - " + provider.operatingName %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -65,12 +65,12 @@
       }) }}
 
       {{ govukWarningText({
-        text: "Removing a contact is permanent – you cannot undo it.",
+        text: "Deleting a contact is permanent – you cannot undo it.",
         iconFallbackText: "Warning"
       }) }}
 
       {{ govukButton({
-        text: "Remove contact",
+        text: "Delete contact",
         classes: "govuk-button--warning"
       }) }}
 

--- a/app/views/providers/contacts/index.njk
+++ b/app/views/providers/contacts/index.njk
@@ -54,7 +54,7 @@
               items: [
                 {
                   href: actions.delete + "/" + contact.id + "/delete",
-                  text: "Remove",
+                  text: "Delete",
                   visuallyHiddenText: "contact " + loop.index
                 },
                 {


### PR DESCRIPTION
This PR:

- creates a `provider_contact_revisions` table/migration
- creates a `providerContactRevision` model
- adds hooks to the `providerContact` model to log create and update statements (we soft delete, so no need to track deletions)
- changed action language from 'Remove' to 'Delete'