### PR TITLE
Create 'user revisions' functionality

### DIFF
--- a/app/constants/revisionFields.js
+++ b/app/constants/revisionFields.js
@@ -40,5 +40,12 @@ module.exports = {
     'telephone',
     'deletedAt',
     'deletedById'
+  ],
+  user: [
+    'firstName',
+    'lastName',
+    'email',
+    'deletedAt',
+    'deletedById'
   ]
 }

--- a/app/migrations/20250509122209-create-user-revision.js
+++ b/app/migrations/20250509122209-create-user-revision.js
@@ -1,0 +1,70 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('user_revisions', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        }
+      },
+      first_name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      last_name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      created_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_by_id: {
+        type: Sequelize.UUID,
+        allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE
+      },
+      deleted_by_id: {
+        type: Sequelize.UUID
+      },
+      revision_number: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      revision_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      revision_by_id: {
+        type: Sequelize.UUID,
+        allowNull: true
+      }
+    })
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('user_revisions')
+  }
+}

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -12,82 +12,97 @@ module.exports = (sequelize) => {
     }
   }
 
-  User.init({
-    id: {
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4,
-      allowNull: false,
-      primaryKey: true
-    },
-    firstName: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      field: 'first_name',
-      validate: {
-        notEmpty: true
+  User.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      firstName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'first_name',
+        validate: {
+          notEmpty: true
+        }
+      },
+      lastName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'last_name',
+        validate: {
+          notEmpty: true
+        }
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          isEmail: true
+        }
+      },
+      password: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'bat'
+      },
+      isActive: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
       }
     },
-    lastName: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      field: 'last_name',
-      validate: {
-        notEmpty: true
-      }
-    },
-    email: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      validate: {
-        notEmpty: true,
-        isEmail: true
-      }
-    },
-    password: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: 'bat'
-    },
-    isActive: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: true
-    },
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      field: 'created_at'
-    },
-    createdById: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      field: 'created_by_id'
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      field: 'updated_at'
-    },
-    updatedById: {
-      type: DataTypes.UUID,
-      allowNull: false,
-      field: 'updated_by_id'
-    },
-    deletedAt: {
-      type: DataTypes.DATE,
-      field: 'deleted_at'
-    },
-    deletedById: {
-      type: DataTypes.UUID,
-      field: 'deleted_by_id'
+    {
+      sequelize,
+      modelName: 'User',
+      tableName: 'users',
+      timestamps: true
     }
-  },
-  {
-    sequelize,
-    modelName: 'User',
-    tableName: 'users',
-    timestamps: true
-  })
+  )
+
+  const createRevisionHook = require('../hooks/revisionHook')
+
+  User.addHook('afterCreate', (instance, options) =>
+    createRevisionHook({ revisionModelName: 'UserRevision', modelKey: 'user' })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
+  User.addHook('afterUpdate',
+    createRevisionHook({ revisionModelName: 'UserRevision', modelKey: 'user' })
+  )
 
   return User
 }

--- a/app/models/userRevision.js
+++ b/app/models/userRevision.js
@@ -71,14 +71,6 @@ module.exports = (sequelize) => {
         allowNull: false,
         field: 'updated_by_id'
       },
-      archivedAt: {
-        type: DataTypes.DATE,
-        field: 'archived_at'
-      },
-      archivedById: {
-        type: DataTypes.UUID,
-        field: 'archived_by_id'
-      },
       deletedAt: {
         type: DataTypes.DATE,
         field: 'deleted_at'

--- a/app/models/userRevision.js
+++ b/app/models/userRevision.js
@@ -1,0 +1,113 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class UserRevision extends Model {
+    static associate(models) {
+      UserRevision.belongsTo(models.User, {
+        foreignKey: 'userId',
+        as: 'user'
+      })
+
+      UserRevision.belongsTo(models.User, {
+        foreignKey: 'revisionById',
+        as: 'revisionByUser'
+      })
+    }
+  }
+
+  UserRevision.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true
+      },
+      userId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'user_id'
+      },
+      firstName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'first_name',
+        validate: {
+          notEmpty: true
+        }
+      },
+      lastName: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        field: 'last_name',
+        validate: {
+          notEmpty: true
+        }
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          notEmpty: true,
+          isEmail: true
+        }
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      archivedAt: {
+        type: DataTypes.DATE,
+        field: 'archived_at'
+      },
+      archivedById: {
+        type: DataTypes.UUID,
+        field: 'archived_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      },
+      revisionNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        field: 'revision_number'
+      },
+      revisionAt: {
+        type: DataTypes.DATE,
+        field: 'revision_at'
+      },
+      revisionById: {
+        type: DataTypes.UUID,
+        field: 'revision_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'UserRevision',
+      tableName: 'user_revisions',
+      timestamps: false
+    }
+  )
+
+  return UserRevision
+}


### PR DESCRIPTION
This PR:

- creates a `user_revisions` table/migration
- creates a `userRevision` model
- adds hooks to the `user` model to log create and update statements (we soft delete, so no need to track deletions)