### PR TITLE
Log revision activity

### DIFF
--- a/app/hooks/activityHook.js
+++ b/app/hooks/activityHook.js
@@ -1,0 +1,37 @@
+const { logActivity } = require('../utils/activityLogger')
+
+/**
+ * Creates a Sequelize-compatible hook to log activity when a revision is created.
+ *
+ * @param {Object} config
+ * @param {string} config.entityType - Logical type of the entity (e.g. 'user', 'provider')
+ * @param {string} config.revisionTable - Name of the revision table in the DB
+ * @param {string} config.entityIdField - Field name on the revision model that links to the entity
+ * @returns {Function} Sequelize hook function (instance, options) => void
+ */
+function createActivityHook({ entityType, revisionTable, entityIdField }) {
+  return async function (instance, options) {
+    const revisionId = instance.id
+    const entityId = instance[entityIdField]
+    const revisionNumber = instance.revisionNumber
+    const changedById = instance.updatedById
+    const changedAt = instance.updatedAt
+
+    if (!revisionId || !entityId) {
+      console.warn(`[ActivityHook] Skipped logging activity — missing revisionId (${revisionId}) or entityId (${entityId})`)
+      return
+    }
+
+    await logActivity({
+      revisionTable,
+      revisionId,
+      entityType,
+      entityId,
+      revisionNumber,
+      changedById,
+      changedAt
+    }, options)
+  }
+}
+
+module.exports = createActivityHook

--- a/app/migrations/20250509143902-create-activity-log.js
+++ b/app/migrations/20250509143902-create-activity-log.js
@@ -1,0 +1,59 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('activity_logs', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      revision_table: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        comment: 'The name of the table where the revision occurred (e.g. provider_revisions)',
+      },
+      revision_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        comment: 'The ID of the revision record (e.g. in provider_revisions)',
+      },
+      entity_type: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        comment: 'High-level type of entity (e.g. provider, user)',
+      },
+      entity_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        comment: 'The ID of the entity affected by the revision (e.g. provider.id)',
+      },
+      revision_number: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      changed_by_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        comment: 'The user who made the change',
+      },
+      changed_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('activity_logs');
+  }
+};

--- a/app/models/activityLog.js
+++ b/app/models/activityLog.js
@@ -1,0 +1,59 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class ActivityLog extends Model {
+    static associate(models) {
+      ActivityLog.belongsTo(models.User, {
+        foreignKey: 'changedById',
+        as: 'changedByUser'
+      })
+    }
+  }
+
+  ActivityLog.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      revisionTable: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      revisionId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      entityType: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      entityId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+      },
+      revisionNumber: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      changedById: {
+        type: DataTypes.UUID,
+        allowNull: true,
+      },
+      changedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      }
+    },
+    {
+      sequelize,
+      modelName: 'ActivityLog',
+      tableName: 'activity_logs',
+      underscored: true
+    }
+  )
+
+  return ActivityLog
+}

--- a/app/models/providerAccreditationRevision.js
+++ b/app/models/providerAccreditationRevision.js
@@ -100,5 +100,18 @@ module.exports = (sequelize) => {
     }
   )
 
+  const createActivityHook = require('../hooks/activityHook')
+
+  ProviderAccreditationRevision.addHook('afterCreate', (instance, options) =>
+    createActivityHook({
+      entityType: 'provider_accreditation',
+      revisionTable: 'provider_accreditation_revisions',
+      entityIdField: 'providerAccreditationId'
+    })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
   return ProviderAccreditationRevision
 }

--- a/app/models/providerAddressRevision.js
+++ b/app/models/providerAddressRevision.js
@@ -132,5 +132,18 @@ module.exports = (sequelize) => {
     }
   )
 
+  const createActivityHook = require('../hooks/activityHook')
+
+  ProviderAddressRevision.addHook('afterCreate', (instance, options) =>
+    createActivityHook({
+      entityType: 'provider_address',
+      revisionTable: 'provider_address_revisions',
+      entityIdField: 'providerAddressId'
+    })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
   return ProviderAddressRevision
 }

--- a/app/models/providerContactRevision.js
+++ b/app/models/providerContactRevision.js
@@ -112,5 +112,18 @@ module.exports = (sequelize) => {
     }
   )
 
+  const createActivityHook = require('../hooks/activityHook')
+
+  ProviderContactRevision.addHook('afterCreate', (instance, options) =>
+    createActivityHook({
+      entityType: 'provider_contact',
+      revisionTable: 'provider_contact_revisions',
+      entityIdField: 'providerContactId'
+    })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
   return ProviderContactRevision
 }

--- a/app/models/providerRevision.js
+++ b/app/models/providerRevision.js
@@ -128,5 +128,18 @@ module.exports = (sequelize) => {
     }
   )
 
+  const createActivityHook = require('../hooks/activityHook')
+
+  ProviderRevision.addHook('afterCreate', (instance, options) =>
+    createActivityHook({
+      entityType: 'provider',
+      revisionTable: 'provider_revisions',
+      entityIdField: 'providerId'
+    })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
   return ProviderRevision
 }

--- a/app/models/userRevision.js
+++ b/app/models/userRevision.js
@@ -101,5 +101,18 @@ module.exports = (sequelize) => {
     }
   )
 
+  const createActivityHook = require('../hooks/activityHook')
+
+  UserRevision.addHook('afterCreate', (instance, options) =>
+    createActivityHook({
+      entityType: 'user',
+      revisionTable: 'user_revisions',
+      entityIdField: 'userId'
+    })(instance, {
+      ...options,
+      hookName: 'afterCreate'
+    })
+  )
+
   return UserRevision
 }

--- a/app/utils/activityLogger.js
+++ b/app/utils/activityLogger.js
@@ -1,0 +1,35 @@
+/**
+ * Log a revision to the activity log
+ *
+ * @param {Object} options
+ * @param {String} options.revisionTable - Name of the revision table (e.g. 'provider_revisions')
+ * @param {String} options.revisionId - ID of the new revision
+ * @param {String} options.entityType - Type of the entity being changed (e.g. 'provider')
+ * @param {String} options.entityId - ID of the entity (e.g. provider.id)
+ * @param {Number} options.revisionNumber - Incrementing revision number
+ * @param {String} [options.changedById] - User ID who made the change
+ * @param {Date} [options.changedAt] - Timestamp of the change
+ */
+
+// utils/activityLogger.js
+let ActivityLog
+
+async function logActivity({ revisionTable, revisionId, entityType, entityId, revisionNumber, changedById, changedAt }) {
+  if (!ActivityLog) {
+    // Lazy-load after all models have been registered
+    const db = require('../models')
+    ActivityLog = db.ActivityLog
+  }
+
+  await ActivityLog.create({
+    revisionTable,
+    revisionId,
+    entityType,
+    entityId,
+    revisionNumber,
+    changedById,
+    changedAt
+  })
+}
+
+module.exports = { logActivity }


### PR DESCRIPTION
This PR:

- creates an activity log combining activity across all `_revisions` tables
- adds hooks to all revision models to log activity to the `activity_logs` table
