### PR TITLE
Group the activity log items by day

### DIFF
--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -1,5 +1,5 @@
 const { ActivityLog } = require('../models')
-const { getActivityLogs } = require('../helpers/activityLog')
+const { getActivityLogs, groupActivityLogsByDate } = require('../helpers/activityLog')
 const Pagination = require('../helpers/pagination')
 
 exports.activityList = async (req, res) => {
@@ -13,9 +13,11 @@ exports.activityList = async (req, res) => {
 
   const activityItems = await getActivityLogs({ limit, offset })
 
+  const groupedItems = groupActivityLogsByDate(activityItems)
+
   // create the Pagination object
   // using the chunk + the overall total count
-  const pagination = new Pagination(activityItems, totalCount, page, limit)
+  const pagination = new Pagination(groupedItems, totalCount, page, limit)
 
   res.render('activity/index', {
     activityItems: pagination.getData(),

--- a/app/helpers/date.js
+++ b/app/helpers/date.js
@@ -15,6 +15,11 @@ const ALLOWED_VALUES_FOR_MONTHS = [
   ['12', 'dec', 'december']
 ]
 
+/**
+ * Formats a timestamp into GOV.UK date format (e.g. "5 May 2024").
+ * @param {Date|string} timestamp - A JS Date object or a date string.
+ * @returns {string} The formatted date string.
+ */
 const govukDate = (timestamp) => {
   const format = 'd MMMM yyyy'
 
@@ -27,6 +32,11 @@ const govukDate = (timestamp) => {
   return datetime
 }
 
+/**
+ * Formats a timestamp into a 12-hour GOV.UK-style time string (e.g. "3pm", "12am (midnight)").
+ * @param {Date|string} timestamp - A JS Date object or a date string.
+ * @returns {string} The formatted time string.
+ */
 const govukTime = (timestamp) => {
   let datetime = DateTime.fromJSDate(timestamp, { locale: 'en-GB' })
 
@@ -48,6 +58,12 @@ const govukTime = (timestamp) => {
   return time
 }
 
+/**
+ * Combines GOV.UK-style formatted date and time into a single string.
+ * @param {Date|string} timestamp - A date/time string or object.
+ * @param {boolean|string} [format=false] - If 'on', outputs "time on date".
+ * @returns {string} A human-readable string combining date and time.
+ */
 const govukDateTime = (timestamp, format = false) => {
   if (timestamp === 'today' || timestamp === 'now') {
     timestamp = DateTime.now().toString()
@@ -59,6 +75,11 @@ const govukDateTime = (timestamp, format = false) => {
   return format === 'on' ? `${time} on ${date}` : `${date} at ${time}`
 }
 
+/**
+ * Parses user input into a numeric month value if it matches allowed formats.
+ * @param {string} input - Raw user input for a month (e.g. "Feb", "2", "02").
+ * @returns {string|undefined} The normalised numeric month as string or undefined.
+ */
 const parseMonth = (input) => {
   if (input == null) return undefined
   const trimmedLowerCaseInput = input.trim().toLowerCase()
@@ -67,6 +88,12 @@ const parseMonth = (input) => {
   )?.[0]
 }
 
+/**
+ * Converts a date input object (e.g. from a form) into an ISO date string.
+ * @param {Object} object - Object containing date fields.
+ * @param {string} [namePrefix] - Optional prefix for date field names.
+ * @returns {string} ISO date string (e.g. "2024-05-20") or partial (e.g. "2024-05").
+ */
 const isoDateFromDateInput = (object, namePrefix) => {
   let day, month, year
 
@@ -91,12 +118,21 @@ const isoDateFromDateInput = (object, namePrefix) => {
   }
 }
 
+/**
+ * Checks whether a given value is a valid Date.
+ * @param {*} value - Any input value.
+ * @returns {boolean} True if the value can be parsed into a valid Date.
+ */
 const isValidDate = (value) => {
   const date = new Date(value)
   return date instanceof Date && !isNaN(date)
 }
 
-// Single function returning day, month, and year as an object:
+/**
+ * Extracts day, month and year parts from a timestamp.
+ * @param {Date|string} timestamp - The date to extract parts from.
+ * @returns {{day: number, month: number, year: number}|null}
+ */
 const getDateParts = (timestamp) => {
   if (!isValidDate(timestamp)) {
     return null
@@ -106,12 +142,16 @@ const getDateParts = (timestamp) => {
 
   return {
     day: date.getDate(),
-    month: date.getMonth() + 1, // getMonth() is zero-based
+    month: date.getMonth() + 1,
     year: date.getFullYear()
   }
 }
 
-// Individual helper functions:
+/**
+ * Extracts the day from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Day of the month, or null if invalid.
+ */
 const getDay = (timestamp) => {
   if (!isValidDate(timestamp)) {
     return null
@@ -120,14 +160,24 @@ const getDay = (timestamp) => {
   return new Date(timestamp).getDate()
 }
 
+/**
+ * Extracts the month from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Month (1–12), or null if invalid.
+ */
 const getMonth = (timestamp) => {
   if (!isValidDate(timestamp)) {
     return null
   }
 
-  return new Date(timestamp).getMonth() + 1 // getMonth() is zero-based
+  return new Date(timestamp).getMonth() + 1
 }
 
+/**
+ * Extracts the year from a timestamp.
+ * @param {Date|string} timestamp - The date to extract from.
+ * @returns {number|null} Year, or null if invalid.
+ */
 const getYear = (timestamp) => {
   if (!isValidDate(timestamp)) {
     return null
@@ -187,7 +237,6 @@ function isYesterday(input) {
     date.getDate() === yesterday.getDate()
   )
 }
-
 
 module.exports = {
   govukDate,

--- a/app/helpers/date.js
+++ b/app/helpers/date.js
@@ -136,6 +136,59 @@ const getYear = (timestamp) => {
   return new Date(timestamp).getFullYear()
 }
 
+/**
+ * Checks if the given date is today.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+function isToday(input) {
+  const date = new Date(input)
+  const today = new Date()
+
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  )
+}
+
+/**
+ * Checks if the given date is tomorrow.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+function isTomorrow(input) {
+  const date = new Date(input)
+  const tomorrow = new Date()
+
+  tomorrow.setDate(tomorrow.getDate() + 1)
+
+  return (
+    date.getFullYear() === tomorrow.getFullYear() &&
+    date.getMonth() === tomorrow.getMonth() &&
+    date.getDate() === tomorrow.getDate()
+  )
+}
+
+/**
+ * Checks if the given date is yesterday.
+ * @param {Date|string|number} input - A Date object or something convertible to a Date.
+ * @returns {boolean}
+ */
+function isYesterday(input) {
+  const date = new Date(input)
+  const yesterday = new Date()
+
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  return (
+    date.getFullYear() === yesterday.getFullYear() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getDate() === yesterday.getDate()
+  )
+}
+
+
 module.exports = {
   govukDate,
   govukDateTime,
@@ -145,5 +198,8 @@ module.exports = {
   getDateParts,
   getDay,
   getMonth,
-  getYear
+  getYear,
+  isToday,
+  isTomorrow,
+  isYesterday
 }

--- a/app/views/activity/index.njk
+++ b/app/views/activity/index.njk
@@ -17,47 +17,46 @@
 
     {% include "_includes/page-heading.njk" %}
 
-    {% if activityItems.length %}
+      {% if activityItems.length %}
 
-      {% for item in activityItems %}
+      {% for group in activityItems %}
 
-        <h2 class="govuk-summary-card__title">
-          {{ item.summary.activity }}
-        </h2>
-        <p class="govuk-body">
-          {% if item.changedByUser.deleteById %}
-            By Deleted user on {{ item.changedAt | govukDateTime }}
-          {% else %}
-            By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
-          {% endif %}
-        </p>
-        <div class="govuk-summary-card">
-          <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">
-              {# {% if item.summary.href.length %}
-                <a class="govuk-link" href="{{ item.summary.href }}">
-                  {{ item.summary.label }}
-                </a>
-              {% else %} #}
+        <h2 class="govuk-heading-m">{{ group.label }}</h2>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        {% for item in group.entries %}
+          <h3 class="govuk-summary-card__title">
+            {{ item.summary.activity }}
+          </h3>
+          <p class="govuk-body">
+            {% if item.changedByUser.deleteById %}
+              By Deleted user on {{ item.changedAt | govukDateTime }}
+            {% else %}
+              By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
+            {% endif %}
+          </p>
+          <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">
                 {{ item.summary.label }}
-              {# {% endif %} #}
-            </h2>
+              </h2>
+            </div>
+            <div class="govuk-summary-card__content">
+              {% for field in item.summary.fields %}
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      {{ field.key }}
+                    </dt>
+                    <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+                      {{ field.value if field.value else "Not entered" }}
+                    </dd>
+                  </div>
+                </dl>
+              {% endfor %}
+            </div>
           </div>
-          <div class="govuk-summary-card__content">
-            {% for field in item.summary.fields %}
-              <dl class="govuk-summary-list">
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    {{ field.key }}
-                  </dt>
-                  <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
-                    {{ field.value if field.value else "Not entered" }}
-                  </dd>
-                </div>
-              </dl>
-            {% endfor %}
-          </div>
-        </div>
+        {% endfor %}
       {% endfor %}
 
       {% include "_includes/pagination.njk" %}


### PR DESCRIPTION
This PR introduces grouping the global activity log by day to improve the readability of the log.

Subheadings include:

- Today
- Yesterday
- date

We didn't add the headings to the individual provider logs since we don't envisage enough activity to require subheadings. 