### PR TITLE
Update the govuk-tag override for headings

### DIFF
--- a/app/assets/sass/utilities/_overrides.scss
+++ b/app/assets/sass/utilities/_overrides.scss
@@ -1,4 +1,4 @@
-h1 .govuk-tag {
+.govuk-tag__heading {
   position: relative;
   top: -7px;
 }

--- a/app/views/providers/_page-heading.njk
+++ b/app/views/providers/_page-heading.njk
@@ -5,12 +5,13 @@
       {% if provider.deletedAt %}
         {{ govukTag({
           text: "Deleted",
-          classes: "govuk-tag--red"
+          classes: "govuk-tag--red govuk-tag__heading"
         }) }}
       {% else %}
         {% if provider.archivedAt %}
           {{ govukTag({
-            text: "Archived"
+            text: "Archived",
+            classes: "govuk-tag__heading"
           }) }}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
This PR updates the SCSS for headings containing tags