### PR TITLE
Fix service error pages

### DIFF
--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -2,13 +2,13 @@
 
 {% set hidePrimaryNavigation = true %}
 
-{% set title = "Ask for an account to " + serviceName %}
+{% set title = "Ask for an account to access the " + serviceName %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{ title }}</h1>
-      <p class="govuk-body">Although you have a DfE Sign-in account, you also need an account on {{ serviceName }}.</p>
+      <p class="govuk-body">Although you have a DfE Sign-in account, you also need an account to access the {{ serviceName }}.</p>
       <p class="govuk-body">If you think you should have an account, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
     </div>
   </div>

--- a/app/views/layouts/error.njk
+++ b/app/views/layouts/error.njk
@@ -15,10 +15,7 @@
 {% block header %}
   {{ govukHeader({
     rebrand: true,
-    homepageUrl: "/",
-    productName: serviceName,
-    containerClasses: "govuk-width-container",
-    navigationClasses: "govuk-header__navigation--end"
+    homepageUrl: "/"
   }) }}
 
   {% if not hidePhaseBanner %}


### PR DESCRIPTION
This PR updates the:

- `error.njk` layout to remove the service name from the header
- `account-not-recognised.njk` content - https://register-providers-pr-79.herokuapp.com/account-not-recognised