### PR TITLE
Only show partnerships that haven't been deleted

### DIFF
--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -31,7 +31,9 @@ exports.providerPartnershipsList = async (req, res) => {
 
     // fetch the trainingPartnerships sorted
     provider.partnerships = await provider.getTrainingPartnerships({
-      where: { deletedAt: null },
+      through: {
+        where: { deletedAt: null },
+      },
       order: [['operatingName', 'ASC']],
       limit,
       offset
@@ -43,7 +45,9 @@ exports.providerPartnershipsList = async (req, res) => {
 
     // fetch the accreditedPartnerships sorted
     provider.partnerships = await provider.getAccreditedPartnerships({
-      where: { deletedAt: null },
+      through: {
+        where: { deletedAt: null },
+      },
       order: [['operatingName', 'ASC']],
       limit,
       offset

--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -26,22 +26,24 @@ exports.providerPartnershipsList = async (req, res) => {
 
   if (isAccredited) {
     totalCount = await ProviderPartnership.count({
-      where: { accreditedProviderId: providerId }
+      where: { accreditedProviderId: providerId, deletedAt: null }
     })
 
     // fetch the trainingPartnerships sorted
     provider.partnerships = await provider.getTrainingPartnerships({
+      where: { deletedAt: null },
       order: [['operatingName', 'ASC']],
       limit,
       offset
     })
   } else {
     totalCount = await ProviderPartnership.count({
-      where: { trainingProviderId: providerId }
+      where: { trainingProviderId: providerId, deletedAt: null }
     })
 
     // fetch the accreditedPartnerships sorted
     provider.partnerships = await provider.getAccreditedPartnerships({
+      where: { deletedAt: null },
       order: [['operatingName', 'ASC']],
       limit,
       offset

--- a/app/helpers/partnership.js
+++ b/app/helpers/partnership.js
@@ -4,7 +4,8 @@ const hasPartnership = async (params) => {
   const partnershipCount = await ProviderPartnership.count({
     where: {
       accreditedProviderId: params.accreditedProviderId,
-      trainingProviderId: params.trainingProviderId
+      trainingProviderId: params.trainingProviderId,
+      deletedAt: null
     }
   })
 


### PR DESCRIPTION
This PR fixes a couple of issues:

- Only show partnerships in the partnerships list that haven't been deleted
- Add a check in the `hasPartnership` helper function that checks if the relationship hasn't been deleted - i.e., if a relationship has been previously deleted, we don't need to check for duplicates

This PR doesn't address updating relationships if a provider has been deleted.