### PR TITLE
Fallback to a standard input if JavaScript is disabled

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,3 +9,12 @@ $app-assets-path: "/public/";
 // Components that aren’t in GOV.UK Frontend
 @import "components/filter-layout";
 @import "components/search-results";
+
+
+.js-enabled-only {
+  display: none;
+}
+
+.js-enabled .js-enabled-only {
+  display: block;
+}

--- a/app/views/providers/partnerships/find.njk
+++ b/app/views/providers/partnerships/find.njk
@@ -32,19 +32,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    {% set headingHtml %}
-      {% include "_includes/page-heading-legend.njk" %}
-    {% endset %}
+    {% include "_includes/page-heading.njk" %}
 
     <form id="provider-search" action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
       {# Hidden field to store the provider ID #}
       <input type="hidden" id="selected-provider-id" name="provider[id]" value="{{ data.provider.id | default('') }}">
 
       <div class="govuk-form-group {{- ' govuk-form-group--error' if errors.length }}">
-        <label class="govuk-label govuk-label--l" for="provider-autocomplete">
-          <span class="govuk-caption-l">{{ caption }} </span>
-          {{ title }}
-        </label>
+        <div class="autocomplete__fallback">
+          {{ govukInput({
+            id: "provider",
+            name: "search",
+            value: data.search,
+            autocomplete: "off",
+            formGroup: {
+              classes: "govuk-!-margin-bottom-0"
+            },
+            errorMessage: errors | getErrorMessage("provider")
+          }) }}
+        </div>
         <div id="provider-autocomplete-container" class="govuk-body"></div>
       </div>
 
@@ -54,10 +60,12 @@
         </p>
       {% endset %}
 
-      {{ govukDetails({
-        summaryText: "I cannot find the " + ("training partner" if isAccredited else "accredited provider"),
-        html: helpText
-      }) }}
+      <div class="js-enabled-only" hidden>
+        {{ govukDetails({
+          summaryText: "I cannot find the " + ("training partner" if isAccredited else "accredited provider"),
+          html: helpText
+        }) }}
+      </div>
 
       {{ govukButton({
         text: "Continue"
@@ -77,7 +85,28 @@
 {% block pageScripts %}
 <script src="/public/javascripts/vendor/accessible-autocomplete.min.js"></script>
 <script>
+document.documentElement.classList.add('js-enabled');
+
 document.addEventListener('DOMContentLoaded', function () {
+  const fallbackInput = document.getElementById('provider');
+  if (fallbackInput) {
+    fallbackInput.disabled = true;
+  }
+
+  const fallback = document.querySelector('.autocomplete__fallback');
+  const enhanced = document.querySelector('#provider-autocomplete-container');
+
+  if (fallback && enhanced) {
+    fallback.style.display = 'none';
+    enhanced.removeAttribute('hidden');
+
+    // Disable the fallback input so it doesn't get submitted
+    const fallbackInput = document.getElementById('provider');
+    if (fallbackInput) {
+      fallbackInput.disabled = true;
+    }
+  }
+
   let providerMap = []; // store providers for potential auto-match on submit
 
   accessibleAutocomplete({
@@ -85,6 +114,8 @@ document.addEventListener('DOMContentLoaded', function () {
     id: 'provider-autocomplete',
     name: 'search', // <--- Use 'search' as the name of the generated input
     defaultValue: '{{ data["search"] | default("") }}', // re-populate typed text
+    // add an aria-label for screen readers instead of a second visible label
+    ariaLabel: '{{ title }}',
     source: function (query, populateResults) {
       // If user hasn't typed anything, return no suggestions
       if (!query || query.length < 3) {


### PR DESCRIPTION
This PR implements a fallback to a standard input if JavaScript is disabled for the 'Add partnership' flow provider autocomplete.

| With JavaScript | Without JavaScript |
| --- | --- |
| ![Screenshot 2025-06-03 at 15 53 19@2x](https://github.com/user-attachments/assets/408e7395-7a2e-40ed-8b30-5c02d38456ee) | ![Screenshot 2025-06-03 at 15 53 53@2x](https://github.com/user-attachments/assets/3db6e2be-398e-4663-b569-635843d04345) |

With JavaScript, we show:

- an autocomplete with the relevant providers listed
- a govukDetails component titled "I cannot find the [training partner|accredited provider]"

Without JavaScript, we show:

- a standard govukInput - when the page is submitted, users must select a provider from the radio options presented, or change their search