### PR TITLE
Updated add partnership flow

### DIFF
--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -221,7 +221,7 @@ exports.newProviderPartnership_post = async (req, res) => {
       res.redirect(`/providers/${providerId}/partnerships/new/duplicate`)
     } else {
       if (selectedProviderId) {
-        res.redirect(`/providers/${providerId}/partnerships/new/check`)
+        res.redirect(`/providers/${providerId}/partnerships/new/accreditations`)
       } else {
         res.redirect(`/providers/${providerId}/partnerships/new/choose`)
       }
@@ -320,6 +320,53 @@ exports.newProviderPartnershipChoose_post = async (req, res) => {
         back: `/providers/${providerId}/partnerships/new`,
         cancel: `/providers/${providerId}/partnerships`,
         save: `/providers/${providerId}/partnerships/new/choose`
+      }
+    })
+  } else {
+    res.redirect(`/providers/${providerId}/partnerships/new/accreditations`)
+  }
+}
+
+exports.newProviderPartnershipAccreditations_get = async (req, res) => {
+  const { providerId } = req.params
+  const provider = await Provider.findByPk(providerId)
+  const partner = await Provider.findByPk(req.session.data.provider.id)
+
+  // TODO
+  const accreditationItems = []
+
+  res.render('providers/partnerships/accreditations', {
+    provider,
+    partner,
+    accreditationItems,
+    actions: {
+      back: `/providers/${providerId}/partnerships/new`,
+      cancel: `/providers/${providerId}/partnerships`,
+      save: `/providers/${providerId}/partnerships/new/accreditations`
+    }
+  })
+}
+
+exports.newProviderPartnershipAccreditations_post = async (req, res) => {
+  const { providerId } = req.params
+  const provider = await Provider.findByPk(providerId)
+  const partner = await Provider.findByPk(req.session.data.provider.id)
+
+  // TODO
+  const accreditationItems = []
+
+  const errors = []
+
+  if (errors.length > 0) {
+    res.render('providers/partnerships/accreditations', {
+      provider,
+      partner,
+      accreditationItems,
+      errors,
+      actions: {
+        back: `/providers/${providerId}/partnerships/new`,
+        cancel: `/providers/${providerId}/partnerships`,
+        save: `/providers/${providerId}/partnerships/new/accreditations`
       }
     })
   } else {

--- a/app/helpers/accreditation.js
+++ b/app/helpers/accreditation.js
@@ -36,6 +36,28 @@ const isAccreditedProvider = async (params) => {
   return isAccredited
 }
 
+/**
+ * Get details for a list of accreditation IDs.
+ * @param {Array<string>} accreditationIds - Array of accreditation UUIDs
+ * @returns {Promise<Array<Object>>} Array of ProviderAccreditation objects
+ */
+const getAccreditationDetails = async (accreditationIds) => {
+  if (!Array.isArray(accreditationIds) || accreditationIds.length === 0) {
+    return []
+  }
+
+  const accreditations = await ProviderAccreditation.findAll({
+    where: {
+      id: {
+        [Op.in]: accreditationIds
+      }
+    }
+  })
+
+  return accreditations.map(accreditation => accreditation.toJSON())
+}
+
 module.exports = {
-  isAccreditedProvider
+  isAccreditedProvider,
+  getAccreditationDetails
 }

--- a/app/migrations/20250624150000-create-provider-accreditation-partnership.js
+++ b/app/migrations/20250624150000-create-provider-accreditation-partnership.js
@@ -11,7 +11,7 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false
       },
-      provider_id: {
+      partner_id: {
         type: Sequelize.UUID,
         allowNull: false
       },

--- a/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js.js
+++ b/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js.js
@@ -15,7 +15,7 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false
       },
-      provider_id: {
+      partner_id: {
         type: Sequelize.UUID,
         allowNull: false
       },

--- a/app/models/providerAccreditationPartnership.js
+++ b/app/models/providerAccreditationPartnership.js
@@ -79,18 +79,18 @@ module.exports = (sequelize) => {
     }
   )
 
-  const createRevisionHook = require('../hooks/revisionHook')
+  // const createRevisionHook = require('../hooks/revisionHook')
 
-  ProviderAccreditationPartnership.addHook('afterCreate', (instance, options) =>
-    createRevisionHook({ revisionModelName: 'ProviderAccreditationPartnershipRevision', modelKey: 'providerAccreditationPartnership' })(instance, {
-      ...options,
-      hookName: 'afterCreate'
-    })
-  )
+  // ProviderAccreditationPartnership.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'ProviderAccreditationPartnershipRevision', modelKey: 'providerAccreditationPartnership' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
 
-  ProviderAccreditationPartnership.addHook('afterUpdate',
-    createRevisionHook({ revisionModelName: 'ProviderAccreditationPartnershipRevision', modelKey: 'providerAccreditationPartnership' })
-  )
+  // ProviderAccreditationPartnership.addHook('afterUpdate',
+  //   createRevisionHook({ revisionModelName: 'ProviderAccreditationPartnershipRevision', modelKey: 'providerAccreditationPartnership' })
+  // )
 
   return ProviderAccreditationPartnership
 }

--- a/app/models/providerAccreditationPartnership.js
+++ b/app/models/providerAccreditationPartnership.js
@@ -4,8 +4,8 @@ module.exports = (sequelize) => {
   class ProviderAccreditationPartnership extends Model {
     static associate(models) {
       ProviderAccreditationPartnership.belongsTo(models.Provider, {
-        foreignKey: 'providerId',
-        as: 'provider'
+        foreignKey: 'partnerId',
+        as: 'partner'
       })
 
       ProviderAccreditationPartnership.belongsTo(models.ProviderAccreditation, {
@@ -37,10 +37,10 @@ module.exports = (sequelize) => {
         allowNull: false,
         field: 'provider_accreditation_id'
       },
-      providerId: {
+      partnerId: {
         type: DataTypes.UUID,
         allowNull: false,
-        field: 'provider_id'
+        field: 'partner_id'
       },
       createdAt: {
         type: DataTypes.DATE,

--- a/app/models/providerAccreditationPartnershipRevision.js
+++ b/app/models/providerAccreditationPartnershipRevision.js
@@ -9,8 +9,8 @@ module.exports = (sequelize) => {
       })
 
       ProviderAccreditationPartnershipRevision.belongsTo(models.Provider, {
-        foreignKey: 'providerId',
-        as: 'provider'
+        foreignKey: 'partnerId',
+        as: 'partner'
       })
 
       ProviderAccreditationPartnershipRevision.belongsTo(models.User, {
@@ -37,10 +37,10 @@ module.exports = (sequelize) => {
         allowNull: false,
         field: 'provider_accreditation_id'
       },
-      providerId: {
+      partnerId: {
         type: DataTypes.UUID,
         allowNull: false,
-        field: 'provider_id'
+        field: 'partner_id'
       },
       createdAt: {
         type: DataTypes.DATE,

--- a/app/routes.js
+++ b/app/routes.js
@@ -185,6 +185,9 @@ router.get('/providers/:providerId/partnerships/new/duplicate', checkIsAuthentic
 router.get('/providers/:providerId/partnerships/new/choose', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipChoose_get)
 router.post('/providers/:providerId/partnerships/new/choose', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipChoose_post)
 
+router.get('/providers/:providerId/partnerships/new/accreditations', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipAccreditations_get)
+router.post('/providers/:providerId/partnerships/new/accreditations', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipAccreditations_post)
+
 router.get('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_get)
 router.post('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_post)
 

--- a/app/services/partnerships.js
+++ b/app/services/partnerships.js
@@ -7,9 +7,9 @@ const savePartnerships = async ({ accreditationIds, partnerId, userId }) => {
     providerAccreditationId: accreditationId,
     partnerId,
     createdAt: timestamp,
-    createdBy: userId,
+    createdById: userId,
     updatedAt: timestamp,
-    updatedBy: userId
+    updatedById: userId
   }))
 
   return ProviderAccreditationPartnership.bulkCreate(dataToCreate)

--- a/app/services/partnerships.js
+++ b/app/services/partnerships.js
@@ -1,0 +1,20 @@
+const { ProviderAccreditationPartnership } = require('../models')
+
+const savePartnerships = async ({ accreditationIds, partnerId, userId }) => {
+  const timestamp = new Date()
+
+  const dataToCreate = accreditationIds.map(accreditationId => ({
+    providerAccreditationId: accreditationId,
+    partnerId,
+    createdAt: timestamp,
+    createdBy: userId,
+    updatedAt: timestamp,
+    updatedBy: userId
+  }))
+
+  return ProviderAccreditationPartnership.bulkCreate(dataToCreate)
+}
+
+module.exports = {
+  savePartnerships
+}

--- a/app/views/providers/partnerships/accreditations.njk
+++ b/app/views/providers/partnerships/accreditations.njk
@@ -3,19 +3,19 @@
 {% set primaryNavId = "providers" %}
 {% set secondaryNavId = "details" %}
 
-{# TODO:
-if provider isAccredited - show its list of accrediations
-else show the partner's list of accreditations
 
-change page title accordingly
- #}
-
-{% set title = "Accreditations" %}
+{% if isAccredited %}
+  {% set providerName = accreditedProvider.operatingName %}
+  {% set title = "Accreditations" %}
+{% else %}
+  {% set providerName = trainingProvider.operatingName %}
+  {% set title = "Accreditations for " + accreditedProvider.operatingName %}
+{% endif %}
 
 {% if currentPartnership %}
-  {% set caption = provider.operatingName %}
+  {% set caption = providerName %}
 {% else %}
-  {% set caption = "Add partnership - " + provider.operatingName %}
+  {% set caption = "Add partnership - " + providerName %}
 {% endif %}
 
 {% block pageTitle %}
@@ -37,26 +37,26 @@ change page title accordingly
   <div class="govuk-grid-column-two-thirds">
 
     {% set headingHtml %}
-      {% include "_includes/page-heading.njk" %}
+      {% include "_includes/page-heading-legend.njk" %}
     {% endset %}
 
     <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
     {{ govukCheckboxes({
-      idPrefix: "accreditation",
-      name: "provider[accreditations]",
+      idPrefix: "accreditations",
+      name: "accreditations[]",
       fieldset: {
         legend: {
           html: headingHtml,
           isPageHeading: true,
-          classes: "govuk-fieldset__legend--m"
+          classes: "govuk-fieldset__legend--l"
         }
       },
       hint: {
         text: "Select all that apply"
       },
-      errorMessage: errors | getErrorMessage("accreditation"),
-      values: "ITEM",
+      errorMessage: errors | getErrorMessage("accreditations"),
+      values: selectedAccreditations,
       items: accreditationItems
     }) }}
 

--- a/app/views/providers/partnerships/accreditations.njk
+++ b/app/views/providers/partnerships/accreditations.njk
@@ -1,0 +1,76 @@
+{% extends "layouts/main.njk" %}
+
+{% set primaryNavId = "providers" %}
+{% set secondaryNavId = "details" %}
+
+{# TODO:
+if provider isAccredited - show its list of accrediations
+else show the partner's list of accreditations
+
+change page title accordingly
+ #}
+
+{% set title = "Accreditations" %}
+
+{% if currentPartnership %}
+  {% set caption = provider.operatingName %}
+{% else %}
+  {% set caption = "Add partnership - " + provider.operatingName %}
+{% endif %}
+
+{% block pageTitle %}
+  {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+{% include "_includes/error-summary.njk" %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% set headingHtml %}
+      {% include "_includes/page-heading.njk" %}
+    {% endset %}
+
+    <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+    {{ govukCheckboxes({
+      idPrefix: "accreditation",
+      name: "provider[accreditations]",
+      fieldset: {
+        legend: {
+          html: headingHtml,
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: "Select all that apply"
+      },
+      errorMessage: errors | getErrorMessage("accreditation"),
+      values: "ITEM",
+      items: accreditationItems
+    }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+    </p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/providers/partnerships/check-your-answers.njk
+++ b/app/views/providers/partnerships/check-your-answers.njk
@@ -25,72 +25,50 @@
 
     <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
 
+      {% set accreditations %}
+        <ul class="govuk-list">
+          {% for accreditation in accreditationItems %}
+            <li>
+              {{ accreditation.text }}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endset %}
+
       {{ govukSummaryList({
-        card: {
-          title: {
-            text: partner.operatingName
-          },
-          actions: {
-            items: [
-              {
-                href: actions.change,
-                text: "Change",
-                visuallyHiddenText: "partnership"
-              }
-            ]
-          }
-        },
         rows: [
           {
             key: {
-              text: "Provider type"
-            },
-            value: {
-              text: partner.type | getProviderTypeLabel(isAccredited) if partner.type.length else "Not entered",
-              classes: "govuk-hint" if not partner.type.length
-            }
-          },
-          {
-            key: {
-              text: "Operating name"
+              text: "Provider"
             },
             value: {
               text: partner.operatingName
+            },
+            actions: {
+              items: [
+                {
+                  href: actions.change + "?referrer=check",
+                  text: "Change",
+                  visuallyHiddenText: "partner provider"
+                }
+              ]
             }
           },
           {
             key: {
-              text: "Legal name"
+              text: "Accreditations"
             },
             value: {
-              text: partner.legalName if partner.legalName.length else "Not entered",
-              classes: "govuk-hint" if not partner.legalName.length
-            }
-          },
-          {
-            key: {
-              text: "UK provider reference number (UKPRN)"
+              html: accreditations
             },
-            value: {
-              text: partner.ukprn if partner.ukprn.length else "Not entered",
-              classes: "govuk-hint" if not partner.ukprn.length
-            }
-          },
-          {
-            key: {
-              text: "Unique reference number (URN)"
-            },
-            value: {
-              text: partner.urn if partner.urn.length else "Not entered",
-              classes: "govuk-hint" if not partner.urn.length
-            }
-          },
-          {
-            key: {
-              text: "Provider code"
-            },
-            value: {
-              text: partner.code
+            actions: {
+              items: [
+                {
+                  href: actions.change + "/accreditations?referrer=check",
+                  text: "Change",
+                  visuallyHiddenText: "accreditations"
+                }
+              ]
             }
           }
         ]

--- a/app/views/providers/partnerships/check-your-answers.njk
+++ b/app/views/providers/partnerships/check-your-answers.njk
@@ -4,10 +4,16 @@
 
 {% set title = "Check your answers" %}
 
-{% if currentPartnership %}
-  {% set caption = provider.operatingName %}
+{% if isAccredited %}
+  {% set providerName = accreditedProvider.operatingName %}
 {% else %}
-  {% set caption = "Add partnership - " + provider.operatingName %}
+  {% set providerName = trainingProvider.operatingName %}
+{% endif %}
+
+{% if currentPartnership %}
+  {% set caption = providerName %}
+{% else %}
+  {% set caption = "Add partnership - " + providerName %}
 {% endif %}
 
 {% block beforeContent %}
@@ -39,20 +45,37 @@
         rows: [
           {
             key: {
-              text: "Provider"
+              text: "Accredited provider"
             },
             value: {
-              text: partner.operatingName
+              text: accreditedProvider.operatingName
             },
             actions: {
               items: [
                 {
                   href: actions.change + "?referrer=check",
                   text: "Change",
-                  visuallyHiddenText: "partner provider"
+                  visuallyHiddenText: "accredited provider"
                 }
               ]
-            }
+            } if not isAccredited
+          },
+          {
+            key: {
+              text: "Training partner"
+            },
+            value: {
+              text: trainingProvider.operatingName
+            },
+            actions: {
+              items: [
+                {
+                  href: actions.change + "?referrer=check",
+                  text: "Change",
+                  visuallyHiddenText: "training partner"
+                }
+              ]
+            } if isAccredited
           },
           {
             key: {


### PR DESCRIPTION
This PR implements the changes to the 'Add partnership' flow, which includes choosing the accreditation to which the partnership belongs.

This is the first part of the flow. Further work includes:

- listing and viewing partnership details
- changing partnership details - i.e., accreditations
- deleting a partnership
- handling the add partnership flow if there are no valid accreditations
- handling the add partnership flow if the partnership already exists