### PR TITLE
Deleting provider partnerships

### DIFF
--- a/app/views/providers/partnerships/delete.njk
+++ b/app/views/providers/partnerships/delete.njk
@@ -2,14 +2,8 @@
 
 {% set primaryNavId = "providers" %}
 
-{% if isAccredited %}
-  {% set partner = partnership.trainingProvider %}
-{% else %}
-  {% set partner = partnership.accreditedProvider %}
-{% endif %}
-
-{% set title = "Confirm you want to delete the partnership with " + partner.operatingName %}
-{% set caption = "Delete partnership - " + provider.operatingName %}
+{% set title = "Confirm you want to delete the partnership with " + titlePartnerName %}
+{% set caption = "Delete partnership - " + captionProviderName %}
 
 {% block beforeContent %}
 {{ govukBackLink({


### PR DESCRIPTION
This PR updates the delete partnership flow using the new ProviderAccreditationPartnership relationship model.

This is the next part of the partnership changes. Further work includes:

- changing partnership details - i.e., accreditations
- handling the add partnership flow if there are no valid accreditations
- handling the add partnership flow if the partnership already exists