### PR TITLE
Change partnership accreditation details

### DIFF
--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -157,7 +157,7 @@ exports.providerPartnershipsList = async (req, res) => {
     actions: {
       new: `/providers/${providerId}/partnerships/new`,
       delete: `/providers/${providerId}/partnerships`,
-      change: `/providers/${providerId}/partnerships/edit`
+      change: `/providers/${providerId}/partnerships`
     }
   })
 }
@@ -546,6 +546,161 @@ exports.newProviderPartnershipCheck_post = async (req, res) => {
   delete req.session.data.accreditations
 
   req.flash('success', 'Partnership added')
+  res.redirect(`/providers/${providerId}/partnerships`)
+}
+
+/// ------------------------------------------------------------------------ ///
+/// Edit provider partnership
+/// ------------------------------------------------------------------------ ///
+
+exports.editProviderPartnershipAccreditations_get = async (req, res) => {
+  res.send('Edit partnership')
+  // const { providerId } = req.params
+  // const isAccredited = await isAccreditedProvider({ providerId })
+
+  // const selectedProviderId = req.session.data?.provider?.id
+
+  // const selectedAccreditations = req.session.data?.accreditations
+
+  // const providers = isAccredited
+  // ? { accreditedProviderId: providerId, trainingProviderId: selectedProviderId }
+  // : { accreditedProviderId: selectedProviderId, trainingProviderId: providerId }
+
+  // const accreditedProvider = await Provider.findByPk(providers.accreditedProviderId)
+  // const trainingProvider = await Provider.findByPk(providers.trainingProviderId)
+
+  // const providerAccreditations = await ProviderAccreditation.findAll({
+  //   where: {
+  //     providerId: providers.accreditedProviderId,
+  //     deletedAt: null
+  //   }
+  // })
+
+  // const accreditationItems = formatAccreditationItems(providerAccreditations)
+
+  // res.render('providers/partnerships/accreditations', {
+  //   accreditedProvider,
+  //   trainingProvider,
+  //   isAccredited,
+  //   accreditationItems,
+  //   selectedAccreditations,
+  //   actions: {
+  //     back: `/providers/${providerId}/partnerships/new`,
+  //     cancel: `/providers/${providerId}/partnerships`,
+  //     save: `/providers/${providerId}/partnerships/new/accreditations`
+  //   }
+  // })
+}
+
+exports.editProviderPartnershipAccreditations_post = async (req, res) => {
+  // const { providerId } = req.params
+  // const isAccredited = await isAccreditedProvider({ providerId })
+
+  // const selectedProviderId = req.session.data?.provider?.id
+
+  // const selectedAccreditations = req.session.data?.accreditations
+
+  // const providers = isAccredited
+  // ? { accreditedProviderId: providerId, trainingProviderId: selectedProviderId }
+  // : { accreditedProviderId: selectedProviderId, trainingProviderId: providerId }
+
+  // const accreditedProvider = await Provider.findByPk(providers.accreditedProviderId)
+  // const trainingProvider = await Provider.findByPk(providers.trainingProviderId)
+
+  // const providerAccreditations = await ProviderAccreditation.findAll({
+  //   where: {
+  //     providerId: providers.accreditedProviderId,
+  //     deletedAt: null
+  //   }
+  // })
+
+  // const accreditationItems = formatAccreditationItems(providerAccreditations)
+
+  // const errors = []
+
+  // if (!selectedAccreditations.length) {
+  //   const error = {}
+  //   error.fieldName = 'accreditations'
+  //   error.href = '#accreditations'
+  //   error.text = 'Select an accreditation'
+  //   errors.push(error)
+  // }
+
+  // if (errors.length > 0) {
+  //   res.render('providers/partnerships/accreditations', {
+  //     accreditedProvider,
+  //     trainingProvider,
+  //     isAccredited,
+  //     accreditationItems,
+  //     selectedAccreditations,
+  //     errors,
+  //     actions: {
+  //       back: `/providers/${providerId}/partnerships/new`,
+  //       cancel: `/providers/${providerId}/partnerships`,
+  //       save: `/providers/${providerId}/partnerships/new/accreditations`
+  //     }
+  //   })
+  // } else {
+  //   res.redirect(`/providers/${providerId}/partnerships/new/check`)
+  // }
+}
+
+exports.editProviderPartnershipCheck_get = async (req, res) => {
+  // const { providerId } = req.params
+  // const isAccredited = await isAccreditedProvider({ providerId })
+
+  // const selectedProviderId = req.session.data?.provider?.id
+
+  // const providers = isAccredited
+  //   ? { accreditedProviderId: providerId, trainingProviderId: selectedProviderId }
+  //   : { accreditedProviderId: selectedProviderId, trainingProviderId: providerId }
+
+  // const accreditedProvider = await Provider.findByPk(providers.accreditedProviderId)
+  // const trainingProvider = await Provider.findByPk(providers.trainingProviderId)
+
+  // // get the selected accreditations
+  // const selectedAccreditations = await getAccreditationDetails(req.session.data?.accreditations)
+
+  // const accreditationItems = formatAccreditationItems(selectedAccreditations)
+
+  // res.render('providers/partnerships/check-your-answers', {
+  //   accreditedProvider,
+  //   trainingProvider,
+  //   isAccredited,
+  //   accreditationItems,
+  //   actions: {
+  //     back: `/providers/${providerId}/partnerships/new/accreditations?referrer=check`,
+  //     cancel: `/providers/${providerId}/partnerships`,
+  //     change: `/providers/${providerId}/partnerships/new`,
+  //     save: `/providers/${providerId}/partnerships/new/check`
+  //   }
+  // })
+}
+
+exports.editProviderPartnershipCheck_post = async (req, res) => {
+  // // get the providerId from the request for use in subsequent queries
+  // const { providerId } = req.params
+
+  // // get the provider from the session data
+  // const { provider } = req.session.data
+
+  // // get the signed in user
+  // const { user } = req.session.passport
+
+  // // calculate if the provider is accredited
+  // const isAccredited = await isAccreditedProvider({ providerId })
+
+  // await savePartnerships({
+  //   accreditationIds: req.session.data?.accreditations,
+  //   partnerId: isAccredited ? provider.id : providerId,
+  //   userId: user.id
+  // })
+
+  // delete req.session.data.search
+  // delete req.session.data.provider
+  // delete req.session.data.accreditations
+
+  req.flash('success', 'Partnership updated')
   res.redirect(`/providers/${providerId}/partnerships`)
 }
 

--- a/app/controllers/providerPartnership.js
+++ b/app/controllers/providerPartnership.js
@@ -534,7 +534,6 @@ exports.editProviderPartnershipAccreditations_get = async (req, res) => {
   const { providerId, partnershipId } = req.params
 
   const currentProvider = await Provider.findByPk(providerId)
-  // if (!currentProvider) return res.status(404).send('Provider not found')
 
   // Load the original partnership record (one row)
   const initial = await ProviderAccreditationPartnership.findByPk(partnershipId, {
@@ -584,11 +583,8 @@ exports.editProviderPartnershipAccreditations_get = async (req, res) => {
     ]
   })
 
-  const selectedAccreditations = activePartnerships.map(p => p.providerAccreditationId)
+  const selectedAccreditations = req.session.data.accreditations || activePartnerships.map(p => p.providerAccreditationId)
   const accreditationItems = formatAccreditationItems(providerAccreditations)
-
-  // req.session.data = req.session.data || {}
-  // req.session.data.accreditations = selectedAccreditations
 
   res.render('providers/partnerships/accreditations', {
     currentProvider,
@@ -635,7 +631,6 @@ exports.editProviderPartnershipAccreditations_post = async (req, res) => {
   const trainingProvider = initial.partner
   const accreditedProvider = initial.providerAccreditation.provider
   const accreditedProviderId = accreditedProvider.id
-  // const partnerId = initial.partnerId
 
   const providerAccreditations = await ProviderAccreditation.findAll({
     where: {
@@ -678,13 +673,8 @@ exports.editProviderPartnershipAccreditations_post = async (req, res) => {
 exports.editProviderPartnershipCheck_get = async (req, res) => {
   const { providerId, partnershipId } = req.params
   const currentProvider = await Provider.findByPk(providerId)
-  // if (!currentProvider) return res.status(404).send('Provider not found')
 
   const selectedAccreditations = req.session.data?.accreditations || []
-
-  // if (!selectedAccreditations.length) {
-  //   return res.redirect(`/providers/${providerId}/partnerships/${partnershipId}/accreditations`)
-  // }
 
   // Load one row from the partnership to reconstruct both providers
   const initial = await ProviderAccreditationPartnership.findByPk(partnershipId, {
@@ -701,8 +691,6 @@ exports.editProviderPartnershipCheck_get = async (req, res) => {
     ]
   })
 
-  // if (!initial) return res.status(404).send('Partnership not found')
-
   const trainingProvider = initial.partner
   const accreditedProvider = initial.providerAccreditation.provider
   const accreditedProviderId = accreditedProvider.id
@@ -715,7 +703,6 @@ exports.editProviderPartnershipCheck_get = async (req, res) => {
     }
   })
 
-    // Optional: sort accreditations by number or startsOn
   providerAccreditations.sort((a, b) => a.number.localeCompare(b.number))
 
   const accreditationItems = formatAccreditationItems(providerAccreditations)
@@ -728,6 +715,7 @@ exports.editProviderPartnershipCheck_get = async (req, res) => {
     accreditationItems,
     actions: {
       back: `/providers/${providerId}/partnerships/${partnershipId}/accreditations`,
+      change: `/providers/${providerId}/partnerships/${partnershipId}`,
       cancel: `/providers/${providerId}/partnerships`,
       save: `/providers/${providerId}/partnerships/${partnershipId}/check`
     }

--- a/app/routes.js
+++ b/app/routes.js
@@ -191,6 +191,12 @@ router.post('/providers/:providerId/partnerships/new/accreditations', checkIsAut
 router.get('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_get)
 router.post('/providers/:providerId/partnerships/new/check', checkIsAuthenticated, providerPartnershipController.newProviderPartnershipCheck_post)
 
+router.get('/providers/:providerId/partnerships/:partnershipId/accreditations', checkIsAuthenticated, providerPartnershipController.editProviderPartnershipAccreditations_get)
+router.post('/providers/:providerId/partnerships/:partnershipId/accreditations', checkIsAuthenticated, providerPartnershipController.editProviderPartnershipAccreditations_post)
+
+router.get('/providers/:providerId/partnerships/:partnershipId/check', checkIsAuthenticated, providerPartnershipController.editProviderPartnershipCheck_get)
+router.post('/providers/:providerId/partnerships/:partnershipId/check', checkIsAuthenticated, providerPartnershipController.editProviderPartnershipCheck_post)
+
 router.get('/providers/:providerId/partnerships/:partnershipId/delete', checkIsAuthenticated, providerPartnershipController.deleteProviderPartnership_get)
 router.post('/providers/:providerId/partnerships/:partnershipId/delete', checkIsAuthenticated, providerPartnershipController.deleteProviderPartnership_post)
 

--- a/app/views/providers/accreditations/index.njk
+++ b/app/views/providers/accreditations/index.njk
@@ -53,13 +53,13 @@
             actions: {
               items: [
                 {
-                  href: actions.delete + "/" + accreditation.id + "/delete",
-                  text: "Delete",
+                  href: actions.change + "/" + accreditation.id + "/edit",
+                  text: "Change",
                   visuallyHiddenText: "accreditation " + loop.index
                 },
                 {
-                  href: actions.change + "/" + accreditation.id + "/edit",
-                  text: "Change",
+                  href: actions.delete + "/" + accreditation.id + "/delete",
+                  text: "Delete",
                   visuallyHiddenText: "accreditation " + loop.index
                 }
               ]

--- a/app/views/providers/partnerships/accreditations.njk
+++ b/app/views/providers/partnerships/accreditations.njk
@@ -12,7 +12,7 @@
   {% set title = "Accreditations for " + accreditedProvider.operatingName %}
 {% endif %}
 
-{% if currentPartnership %}
+{% if currentProvider %}
   {% set caption = providerName %}
 {% else %}
   {% set caption = "Add partnership - " + providerName %}

--- a/app/views/providers/partnerships/check-your-answers.njk
+++ b/app/views/providers/partnerships/check-your-answers.njk
@@ -35,9 +35,11 @@
 
       {% set accreditations %}
         <ul class="govuk-list">
+
           {% for accreditation in accreditationItems %}
             <li>
-              {{ accreditation.text }}
+              {{ accreditation.text }}<br>
+              <span class="govuk-hint">{{ accreditation.hint.text }}</span>
             </li>
           {% endfor %}
         </ul>

--- a/app/views/providers/partnerships/check-your-answers.njk
+++ b/app/views/providers/partnerships/check-your-answers.njk
@@ -10,10 +10,12 @@
   {% set providerName = trainingProvider.operatingName %}
 {% endif %}
 
-{% if currentPartnership %}
+{% if currentProvider %}
   {% set caption = providerName %}
+  {% set showChangeLinks = false %}
 {% else %}
   {% set caption = "Add partnership - " + providerName %}
+  {% set showChangeLinks = true %}
 {% endif %}
 
 {% block beforeContent %}
@@ -58,7 +60,7 @@
                   visuallyHiddenText: "accredited provider"
                 }
               ]
-            } if not isAccredited
+            } if (not isAccredited) and showChangeLinks
           },
           {
             key: {
@@ -75,7 +77,7 @@
                   visuallyHiddenText: "training partner"
                 }
               ]
-            } if isAccredited
+            } if isAccredited and showChangeLinks
           },
           {
             key: {

--- a/app/views/providers/partnerships/index.njk
+++ b/app/views/providers/partnerships/index.njk
@@ -45,34 +45,34 @@
 
     {% if partnerships.length %}
 
-      {% for item in partnerships %}
+      {% for partnership in partnerships %}
 
         {% set accreditedProviderHtml %}
-          {% if not item.isAccreditedSide %}
-            <a href="/providers/{{ item.accreditedProvider.id }}">
-              {{ item.accreditedProvider.operatingName }}
+          {% if not partnership.isAccreditedSide %}
+            <a href="/providers/{{ partnership.accreditedProvider.id }}">
+              {{ partnership.accreditedProvider.operatingName }}
             </a>
           {% else %}
-            {{ item.accreditedProvider.operatingName }}
+            {{ partnership.accreditedProvider.operatingName }}
           {% endif %}
         {% endset %}
 
         {% set trainingPartnerHtml %}
-          {% if item.isAccreditedSide %}
-            <a href="/providers/{{ item.trainingPartner.id }}">
-              {{ item.trainingPartner.operatingName }}
+          {% if partnership.isAccreditedSide %}
+            <a href="/providers/{{ partnership.trainingPartner.id }}">
+              {{ partnership.trainingPartner.operatingName }}
             </a>
           {% else %}
-            {{ item.trainingPartner.operatingName }}
+            {{ partnership.trainingPartner.operatingName }}
           {% endif %}
         {% endset %}
 
         {% set accreditationsHtml %}
           <ul class="govuk-list">
-            {% for acc in item.accreditations %}
+            {% for accreditation in partnership.accreditations %}
               <li>
-                {{ acc.number }} ({{ acc.startsOn | govukDate }}
-                {% if acc.endsOn %} to {{ acc.endsOn | govukDate }}{% else %} onward{% endif %})
+                {{ accreditation.number }} ({{ accreditation.startsOn | govukDate }}
+                {% if accreditation.endsOn %} to {{ accreditation.endsOn | govukDate }}{% else %} onward{% endif %})
               </li>
             {% endfor %}
           </ul>
@@ -81,17 +81,17 @@
         {{ govukSummaryList({
           card: {
             title: {
-              text: item.trainingPartner.operatingName if item.isAccreditedSide else item.accreditedProvider.operatingName
+              text: partnership.trainingPartner.operatingName if partnership.isAccreditedSide else partnership.accreditedProvider.operatingName
             },
             actions: {
               items: [
                 {
-                  href: actions.change + "/" + item.id + "/accreditations",
+                  href: actions.change + "/" + partnership.id + "/accreditations",
                   text: "Change",
                   visuallyHiddenText: "partner " + loop.index
                 },
                 {
-                  href: actions.delete + "/" + item.id + "/delete",
+                  href: actions.delete + "/" + partnership.id + "/delete",
                   text: "Delete",
                   visuallyHiddenText: "partner " + loop.index
                 }

--- a/app/views/providers/partnerships/index.njk
+++ b/app/views/providers/partnerships/index.njk
@@ -86,7 +86,7 @@
             actions: {
               items: [
                 {
-                  href: actions.change + "/" + item.id,
+                  href: actions.change + "/" + item.id + "/accreditations",
                   text: "Change",
                   visuallyHiddenText: "partner " + loop.index
                 },

--- a/app/views/providers/partnerships/index.njk
+++ b/app/views/providers/partnerships/index.njk
@@ -71,8 +71,9 @@
           <ul class="govuk-list">
             {% for accreditation in partnership.accreditations %}
               <li>
-                {{ accreditation.number }} ({{ accreditation.startsOn | govukDate }}
-                {% if accreditation.endsOn %} to {{ accreditation.endsOn | govukDate }}{% else %} onward{% endif %})
+                {{ accreditation.number }}<br>
+                <span class="govuk-hint">Starts on {{ accreditation.startsOn | govukDate -}}
+                {% if accreditation.endsOn %}, ends on {{ accreditation.endsOn | govukDate }}{% endif %}</span>
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
This PR implements a change partnership flow. Only accreditations can be changed in a partnership.

This is the next part of the partnership changes. Further work includes handling:

- the add partnership flow if there are no valid accreditations
- the add partnership flow if the partnership already exists
- changes to partnerships when an accreditation is deleted
- changing partnership to partners and partnershipId to partnerId