### PR TITLE
Move 'Your account' and 'Sign out' into service navigation

### DIFF
--- a/app/assets/sass/utilities/_overrides.scss
+++ b/app/assets/sass/utilities/_overrides.scss
@@ -2,3 +2,13 @@
   position: relative;
   top: -7px;
 }
+
+.govuk-service-navigation__wrapper {
+  flex-grow: 1;
+}
+
+.app-service-navigation__align-right {
+  @include govuk-media-query($from: tablet) {
+    margin-left: auto;
+  }
+}

--- a/app/views/account/show.njk
+++ b/app/views/account/show.njk
@@ -1,9 +1,6 @@
 {% extends "layouts/auth.njk" %}
 
-{% set headerNavId = "account" %}
-
-{% set hidePrimaryNavigation = true %}
-{% set hideOrganisationSwitcher = true %}
+{% set primaryNavId = "account" %}
 
 {% set title = "Your account" %}
 

--- a/app/views/layouts/auth.njk
+++ b/app/views/layouts/auth.njk
@@ -16,25 +16,25 @@
   {{ govukHeader({
     rebrand: true,
     homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    navigationClasses: "govuk-header__navigation--end",
-    navigation: [
-      {
-        href: "/account",
-        text: "Your account",
-        active: headerNavId == "account"
-      },
-      {
-        href: "/sign-out",
-        text: "Sign out"
-      }
-    ] if not hideAccountNavigation
+    containerClasses: "govuk-width-container"
   }) }}
+
+  {% set navigationEndHtml %}
+    <li class="govuk-service-navigation__item {{- ' govuk-service-navigation__item--active' if primaryNavId == 'account' }} app-service-navigation__align-right">
+      <a class="govuk-service-navigation__link" href="/account" {{- ' aria-current="true"' if primaryNavId == "account" }}>Your account</a>
+    </li>
+    <li class="govuk-service-navigation__item">
+      <a class="govuk-service-navigation__link" href="/">Sign out</a>
+    </li>
+  {% endset %}
 
   {{ govukServiceNavigation({
     navigationId: "primaryNavigation",
     serviceName: serviceName,
-    serviceUrl: "/"
+    serviceUrl: "/",
+    slots: {
+      navigationEnd: navigationEndHtml
+    }
   }) }}
 
   {% include "_includes/phase-banner.njk" %}

--- a/app/views/layouts/auth.njk
+++ b/app/views/layouts/auth.njk
@@ -34,7 +34,7 @@
     serviceUrl: "/",
     slots: {
       navigationEnd: navigationEndHtml
-    }
+    } if not hideAccountNavigation
   }) }}
 
   {% include "_includes/phase-banner.njk" %}

--- a/app/views/layouts/main.njk
+++ b/app/views/layouts/main.njk
@@ -18,20 +18,17 @@
   {{ govukHeader({
     rebrand: true,
     homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    navigationClasses: "govuk-header__navigation--end",
-    navigation: [
-      {
-        href: "/account",
-        text: "Your account",
-        active: headerNavId == "account"
-      },
-      {
-        href: "/sign-out",
-        text: "Sign out"
-      }
-    ]
+    containerClasses: "govuk-width-container"
   }) }}
+
+  {% set navigationEndHtml %}
+    <li class="govuk-service-navigation__item {{- ' govuk-service-navigation__item--active' if primaryNavId == 'account' }} app-service-navigation__align-right">
+      <a class="govuk-service-navigation__link" href="/account" {{- ' aria-current="true"' if primaryNavId == "account" }}>Your account</a>
+    </li>
+    <li class="govuk-service-navigation__item">
+      <a class="govuk-service-navigation__link" href="/">Sign out</a>
+    </li>
+  {% endset %}
 
   {{ govukServiceNavigation({
     navigationId: "primaryNavigation",
@@ -53,7 +50,10 @@
         href: "/activity",
         active: primaryNavId == "activity"
       }
-    ]
+    ],
+    slots: {
+      navigationEnd: navigationEndHtml
+    }
   }) }}
 
   {% include "_includes/phase-banner.njk" %}


### PR DESCRIPTION
This PR moves 'Your account' and 'Sign out' out of the `govukHeader` and into the `govukServiceNavigation`.

Note: We do not have user session management, so the menu options are _hacked_ together for the time being.