### PR TITLE
Update revision tables

### DIFF
--- a/app/hooks/revisionHook.js
+++ b/app/hooks/revisionHook.js
@@ -1,62 +1,109 @@
+/**
+ * Generic revisioning hook.
+ * Creates a new revision row for a model whenever tracked fields change.
+ */
+
 const revisionFields = require('../constants/revisionFields')
 
+/**
+ * @typedef {Object} RevisionHookConfig
+ * @property {string} revisionModelName - The Sequelize model name of the revision table (e.g. 'ProviderContactRevision').
+ * @property {string} modelKey          - Key used in `revisionFields` and to construct FK (e.g. 'providerContact' -> 'providerContactId').
+ */
+
+/**
+ * @typedef {Object} RevisionHookOptions
+ * @property {'afterCreate'|'afterUpdate'|'afterDestroy'} [hookName] - Name of the lifecycle hook that invoked this function.
+ * // Note: Sequelize will pass many other options (transaction, logging, etc.); we keep the type open.
+ */
+
+/**
+ * Factory that returns a Sequelize hook to create revision rows.
+ *
+ * Behaviour:
+ *  - On creation (`afterCreate`), writes revision #1.
+ *  - On updates, compares only fields listed in `revisionFields[modelKey]`;
+ *    if any changed, increments `revisionNumber` and writes a new row.
+ *  - Sets `revisionById` from `updatedById` falling back to `createdById`.
+ *  - Sets `revisionAt` on write (so activities have a stable timestamp).
+ *  - Emits an `activityAction` alongside the create so the activity hook
+ *    can log 'create'/'update' (and 'delete' if you detect soft delete).
+ *
+ * Soft deletes:
+ *  - If you soft-delete on the *source* model (set `deletedAt` then save),
+ *    detect that change here and pass `activityAction: 'delete'`.
+ *
+ * @param {RevisionHookConfig} param0
+ * @returns {(instance: import('sequelize').Model, options?: RevisionHookOptions) => Promise<void>}
+ */
 const createRevisionHook = ({ revisionModelName, modelKey }) => {
-  return async (instance, options) => {
+  return async (instance, options = {}) => {
     const sequelize = instance.sequelize
     const RevisionModel = sequelize.models[revisionModelName]
     const trackedFields = revisionFields[modelKey] || []
 
-    // Compute revisionById from the source row (fallback to null)
+    // Who caused the change
     const revisionById =
       instance.get('updatedById') ||
       instance.get('createdById') ||
       null
 
-    // Only copy fields that actually exist on the revision model
+    // Safely pick only attributes that exist on the revision model
     const src = instance.get({ plain: true })
     const pickForRevision = (obj) => {
       const revisionAttrs = Object.keys(RevisionModel.rawAttributes)
-      const omit = new Set(['id']) // add other auto fields if you like
+      const omit = new Set(['id']) // avoid copying PK from source into revision
       return Object.fromEntries(
         Object.entries(obj).filter(([k]) => revisionAttrs.includes(k) && !omit.has(k))
       )
     }
 
-    // Helper to build the payload consistently
     const buildPayload = (overrides = {}) => ({
       ...pickForRevision(src),
       [`${modelKey}Id`]: instance.id,
       revisionById,
-      // let DB default set revisionAt, or set here:
-      // revisionAt: new Date(),
+      revisionAt: new Date(),
       ...overrides
     })
 
-    // Always create revision on creation
+    // First revision on create
     if (options?.hookName === 'afterCreate') {
-      await RevisionModel.create(buildPayload({ revisionNumber: 1 }))
+      await RevisionModel.create(
+        buildPayload({ revisionNumber: 1 }),
+        /** @type {import('sequelize').CreateOptions & { activityAction?: 'create' }} */ ({
+          activityAction: 'create'
+        })
+      )
       return
     }
 
-    // Get latest revision
+    // Find latest existing revision
     const latest = await RevisionModel.findOne({
       where: { [`${modelKey}Id`]: instance.id },
       order: [['revisionNumber', 'DESC']]
     })
 
     if (!latest) {
-      await RevisionModel.create(buildPayload({ revisionNumber: 1 }))
+      // Shouldn't usually happen, but be resilient
+      await RevisionModel.create(
+        buildPayload({ revisionNumber: 1 }),
+        { activityAction: 'create' }
+      )
       return
     }
 
-    // Compare only tracked fields
-    const hasChanged = trackedFields.some(field => {
-      return instance.get(field) !== latest.get(field)
-    })
+    // Only write a new revision if tracked fields changed
+    const hasChanged = trackedFields.some((field) => instance.get(field) !== latest.get(field))
     if (!hasChanged) return
 
+    // Optional: treat soft delete (deletedAt changed to non-null) as a 'delete'
+    const deletedAtChanged =
+      typeof instance.changed === 'function' ? instance.changed('deletedAt') : false
+    const isDelete = deletedAtChanged && instance.get('deletedAt') != null
+
     await RevisionModel.create(
-      buildPayload({ revisionNumber: latest.revisionNumber + 1 })
+      buildPayload({ revisionNumber: latest.revisionNumber + 1 }),
+      { activityAction: isDelete ? 'delete' : 'update' }
     )
   }
 }

--- a/app/hooks/revisionHook.js
+++ b/app/hooks/revisionHook.js
@@ -14,11 +14,13 @@ const createRevisionHook = ({ revisionModelName, modelKey }) => {
 
     // Only copy fields that actually exist on the revision model
     const src = instance.get({ plain: true })
-    const revisionAttrs = Object.keys(RevisionModel.rawAttributes)
-    const pickForRevision = (obj) =>
-      Object.fromEntries(
-        Object.entries(obj).filter(([k]) => revisionAttrs.includes(k))
+    const pickForRevision = (obj) => {
+      const revisionAttrs = Object.keys(RevisionModel.rawAttributes)
+      const omit = new Set(['id']) // add other auto fields if you like
+      return Object.fromEntries(
+        Object.entries(obj).filter(([k]) => revisionAttrs.includes(k) && !omit.has(k))
       )
+    }
 
     // Helper to build the payload consistently
     const buildPayload = (overrides = {}) => ({

--- a/app/migrations/20250508112700-create-provider-revision.js
+++ b/app/migrations/20250508112700-create-provider-revision.js
@@ -39,32 +39,10 @@ module.exports = {
       website: {
         type: Sequelize.STRING,
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
       archived_at: {
         type: Sequelize.DATE
       },
       archived_by_id: {
-        type: Sequelize.UUID
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
         type: Sequelize.UUID
       },
       revision_number: {

--- a/app/migrations/20250508112700-create-provider-revision.js
+++ b/app/migrations/20250508112700-create-provider-revision.js
@@ -59,6 +59,12 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_revisions', {
+      fields: ['provider_id'],
+      name: 'idx_provider_revisions_provider_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_revisions')

--- a/app/migrations/20250508112700-create-provider-revision.js
+++ b/app/migrations/20250508112700-create-provider-revision.js
@@ -59,12 +59,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_revisions', {
-      fields: ['provider_id'],
-      name: 'idx_provider_revisions_provider_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_revisions')

--- a/app/migrations/20250508161900-create-provider-accreditation-revision.js
+++ b/app/migrations/20250508161900-create-provider-accreditation-revision.js
@@ -48,16 +48,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_accreditation_revisions', {
-      fields: ['provider_id'],
-      name: 'idx_provider_accreditation_revisions_provider_id'
-    })
-    await queryInterface.addIndex('provider_accreditation_revisions', {
-      fields: ['provider_accreditation_id'],
-      name: 'idx_provider_accreditation_revisions_provider_accreditation_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_accreditation_revisions')

--- a/app/migrations/20250508161900-create-provider-accreditation-revision.js
+++ b/app/migrations/20250508161900-create-provider-accreditation-revision.js
@@ -34,28 +34,6 @@ module.exports = {
       ends_on: {
         type: Sequelize.DATE
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250508161900-create-provider-accreditation-revision.js
+++ b/app/migrations/20250508161900-create-provider-accreditation-revision.js
@@ -48,6 +48,16 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_accreditation_revisions', {
+      fields: ['provider_id'],
+      name: 'idx_provider_accreditation_revisions_provider_id'
+    })
+    await queryInterface.addIndex('provider_accreditation_revisions', {
+      fields: ['provider_accreditation_id'],
+      name: 'idx_provider_accreditation_revisions_provider_accreditation_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_accreditation_revisions')

--- a/app/migrations/20250509103203-create-provider-address-revision.js
+++ b/app/migrations/20250509103203-create-provider-address-revision.js
@@ -70,16 +70,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_address_revisions', {
-      fields: ['provider_id'],
-      name: 'idx_provider_address_revisions_provider_id'
-    })
-    await queryInterface.addIndex('provider_address_revisions', {
-      fields: ['provider_address_id'],
-      name: 'idx_provider_address_revisions_provider_address_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_address_revisions')

--- a/app/migrations/20250509103203-create-provider-address-revision.js
+++ b/app/migrations/20250509103203-create-provider-address-revision.js
@@ -70,6 +70,16 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_address_revisions', {
+      fields: ['provider_id'],
+      name: 'idx_provider_address_revisions_provider_id'
+    })
+    await queryInterface.addIndex('provider_address_revisions', {
+      fields: ['provider_address_id'],
+      name: 'idx_provider_address_revisions_provider_address_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_address_revisions')

--- a/app/migrations/20250509103203-create-provider-address-revision.js
+++ b/app/migrations/20250509103203-create-provider-address-revision.js
@@ -56,28 +56,6 @@ module.exports = {
       google_place_id: {
         type: Sequelize.STRING
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250509114718-create-provider-contact-revision.js
+++ b/app/migrations/20250509114718-create-provider-contact-revision.js
@@ -53,16 +53,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_contact_revisions', {
-      fields: ['provider_id'],
-      name: 'idx_provider_contact_revisions_provider_id'
-    })
-    await queryInterface.addIndex('provider_contact_revisions', {
-      fields: ['provider_contact_id'],
-      name: 'idx_provider_contact_revisions_provider_contact_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_contact_revisions')

--- a/app/migrations/20250509114718-create-provider-contact-revision.js
+++ b/app/migrations/20250509114718-create-provider-contact-revision.js
@@ -39,28 +39,6 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250509114718-create-provider-contact-revision.js
+++ b/app/migrations/20250509114718-create-provider-contact-revision.js
@@ -53,6 +53,16 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_contact_revisions', {
+      fields: ['provider_id'],
+      name: 'idx_provider_contact_revisions_provider_id'
+    })
+    await queryInterface.addIndex('provider_contact_revisions', {
+      fields: ['provider_contact_id'],
+      name: 'idx_provider_contact_revisions_provider_contact_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_contact_revisions')

--- a/app/migrations/20250509122209-create-user-revision.js
+++ b/app/migrations/20250509122209-create-user-revision.js
@@ -51,6 +51,12 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('user_revisions', {
+      fields: ['user_id'],
+      name: 'idx_user_revisions_user_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('user_revisions')

--- a/app/migrations/20250509122209-create-user-revision.js
+++ b/app/migrations/20250509122209-create-user-revision.js
@@ -37,28 +37,6 @@ module.exports = {
         allowNull: false,
         defaultValue: true
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250509122209-create-user-revision.js
+++ b/app/migrations/20250509122209-create-user-revision.js
@@ -51,12 +51,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('user_revisions', {
-      fields: ['user_id'],
-      name: 'idx_user_revisions_user_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('user_revisions')

--- a/app/migrations/20250509143902-create-activity-log.js
+++ b/app/migrations/20250509143902-create-activity-log.js
@@ -4,31 +4,31 @@ module.exports = {
       id: {
         type: Sequelize.UUID,
         defaultValue: Sequelize.UUIDV4,
-        primaryKey: true,
+        primaryKey: true
       },
       revision_table: {
         type: Sequelize.STRING,
         allowNull: false,
-        comment: 'The name of the table where the revision occurred (e.g. provider_revisions)',
+        comment: 'The name of the table where the revision occurred (e.g. provider_revisions)'
       },
       revision_id: {
         type: Sequelize.UUID,
         allowNull: false,
-        comment: 'The ID of the revision record (e.g. in provider_revisions)',
+        comment: 'The ID of the revision record (e.g. in provider_revisions)'
       },
       entity_type: {
         type: Sequelize.STRING,
         allowNull: false,
-        comment: 'High-level type of entity (e.g. provider, user)',
+        comment: 'High-level type of entity (e.g. provider, user)'
       },
       entity_id: {
         type: Sequelize.UUID,
         allowNull: false,
-        comment: 'The ID of the entity affected by the revision (e.g. provider.id)',
+        comment: 'The ID of the entity affected by the revision (e.g. provider.id)'
       },
       revision_number: {
         type: Sequelize.INTEGER,
-        allowNull: false,
+        allowNull: false
       },
       action: {
         type: Sequelize.STRING,
@@ -38,23 +38,29 @@ module.exports = {
       changed_by_id: {
         type: Sequelize.UUID,
         allowNull: true,
-        comment: 'The user who made the change',
+        comment: 'The user who made the change'
       },
       changed_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
       },
       created_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
       },
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
       }
+    })
+
+    // indexes
+    await queryInterface.addIndex('activity_logs', {
+      fields: ['revision_id'],
+      name: 'idx_activity_logs_revision_id'
     })
   },
 

--- a/app/migrations/20250516101200-create-provider-partnership-revision.js
+++ b/app/migrations/20250516101200-create-provider-partnership-revision.js
@@ -37,6 +37,20 @@ module.exports = {
         allowNull: true
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_partnership_revisions', {
+      fields: ['provider_partnership_id'],
+      name: 'idx_provider_partnership_revisions_provider_partnership_id'
+    })
+    await queryInterface.addIndex('provider_partnership_revisions', {
+      fields: ['accredited_provider_id'],
+      name: 'idx_provider_partnership_revisions_accredited_provider_id'
+    })
+    await queryInterface.addIndex('provider_partnership_revisions', {
+      fields: ['training_provider_id'],
+      name: 'idx_provider_partnership_revisions_training_provider_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_partnership_revisions')

--- a/app/migrations/20250516101200-create-provider-partnership-revision.js
+++ b/app/migrations/20250516101200-create-provider-partnership-revision.js
@@ -23,28 +23,6 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250516101200-create-provider-partnership-revision.js
+++ b/app/migrations/20250516101200-create-provider-partnership-revision.js
@@ -37,20 +37,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_partnership_revisions', {
-      fields: ['provider_partnership_id'],
-      name: 'idx_provider_partnership_revisions_provider_partnership_id'
-    })
-    await queryInterface.addIndex('provider_partnership_revisions', {
-      fields: ['accredited_provider_id'],
-      name: 'idx_provider_partnership_revisions_accredited_provider_id'
-    })
-    await queryInterface.addIndex('provider_partnership_revisions', {
-      fields: ['training_provider_id'],
-      name: 'idx_provider_partnership_revisions_training_provider_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_partnership_revisions')

--- a/app/migrations/20250624150000-create-provider-accreditation-partnership.js
+++ b/app/migrations/20250624150000-create-provider-accreditation-partnership.js
@@ -38,6 +38,16 @@ module.exports = {
         type: Sequelize.UUID
       }
     })
+
+    // indexes
+    await queryInterface.addIndex('provider_accreditation_partnerships', {
+      fields: ['provider_accreditation_id'],
+      name: 'idx_provider_accreditation_partnerships_provider_accreditation_id'
+    })
+    await queryInterface.addIndex('provider_accreditation_partnerships', {
+      fields: ['partner_id'],
+      name: 'idx_provider_accreditation_partnerships_partner_id'
+    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_accreditation_partnerships')

--- a/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
+++ b/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
@@ -33,16 +33,6 @@ module.exports = {
         allowNull: true
       }
     })
-
-    // indexes
-    await queryInterface.addIndex('provider_accreditation_partnership_revisions', {
-      fields: ['provider_accreditation_id'],
-      name: 'idx_provider_accreditation_partnership_revisions_provider_accreditation_id'
-    })
-    await queryInterface.addIndex('provider_accreditation_partnership_revisions', {
-      fields: ['partner_id'],
-      name: 'idx_provider_accreditation_partnership_revisions_partner_id'
-    })
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('provider_accreditation_partnership_revisions')

--- a/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
+++ b/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
@@ -19,28 +19,6 @@ module.exports = {
         type: Sequelize.UUID,
         allowNull: false
       },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      created_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false
-      },
-      updated_by_id: {
-        type: Sequelize.UUID,
-        allowNull: false
-      },
-      deleted_at: {
-        type: Sequelize.DATE
-      },
-      deleted_by_id: {
-        type: Sequelize.UUID
-      },
       revision_number: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
+++ b/app/migrations/20250624150200-create-provider-accreditation-partnership-revision.js
@@ -35,13 +35,13 @@ module.exports = {
     })
 
     // indexes
-    await queryInterface.addIndex('provider_accreditation_partnerships', {
+    await queryInterface.addIndex('provider_accreditation_partnership_revisions', {
       fields: ['provider_accreditation_id'],
-      name: 'idx_pap_provider_accreditation_id'
+      name: 'idx_provider_accreditation_partnership_revisions_provider_accreditation_id'
     })
-    await queryInterface.addIndex('provider_accreditation_partnerships', {
+    await queryInterface.addIndex('provider_accreditation_partnership_revisions', {
       fields: ['partner_id'],
-      name: 'idx_pap_partner_id'
+      name: 'idx_provider_accreditation_partnership_revisions_partner_id'
     })
   },
   async down(queryInterface, Sequelize) {

--- a/app/migrations/20250930123000-add-indexes-to-revision-tables.js
+++ b/app/migrations/20250930123000-add-indexes-to-revision-tables.js
@@ -1,0 +1,63 @@
+/**
+ * Adds useful indexes to all *-revisions tables:
+ *  - UNIQUE (model_id, revision_number)
+ *  - (model_id, revision_at)
+ *  - (revision_by_id)
+ *  - (revision_at)
+ */
+
+const TABLES = [
+  { table: 'provider_revisions', modelId: 'provider_id' },
+  { table: 'provider_accreditation_revisions', modelId: 'provider_accreditation_id' },
+  { table: 'provider_address_revisions', modelId: 'provider_address_id' },
+  { table: 'provider_contact_revisions', modelId: 'provider_contact_id' },
+  { table: 'provider_partnership_revisions', modelId: 'provider_partnership_id' },
+  { table: 'provider_accreditation_partnership_revisions', modelId: 'provider_accreditation_partnership_id' },
+  { table: 'user_revisions', modelId: 'user_id' }
+]
+
+// Helper to generate consistent index names
+const ixName = (table, suffix) => {
+  return `${table}_${suffix}`
+}
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    for (const { table, modelId } of TABLES) {
+      // 1) Unique (model_id, revision_number)
+      await queryInterface.addIndex(table, {
+        name: ixName(table, `${modelId}_revision_number_uq`),
+        fields: [modelId, 'revision_number'],
+        unique: true
+      })
+
+      // 2) (model_id, revision_at)
+      await queryInterface.addIndex(table, {
+        name: ixName(table, `${modelId}_revision_at_idx`),
+        fields: [modelId, 'revision_at']
+      })
+
+      // 3) (revision_by_id)
+      await queryInterface.addIndex(table, {
+        name: ixName(table, `revision_by_id_idx`),
+        fields: ['revision_by_id']
+      })
+
+      // 4) (revision_at)
+      await queryInterface.addIndex(table, {
+        name: ixName(table, `revision_at_idx`),
+        fields: ['revision_at']
+      })
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    // Remove indexes in reverse order
+    for (const { table, modelId } of [...TABLES].reverse()) {
+      await queryInterface.removeIndex(table, ixName(table, `revision_at_idx`))
+      await queryInterface.removeIndex(table, ixName(table, `revision_by_id_idx`))
+      await queryInterface.removeIndex(table, ixName(table, `${modelId}_revision_at_idx`))
+      await queryInterface.removeIndex(table, ixName(table, `${modelId}_revision_number_uq`))
+    }
+  }
+}

--- a/app/models/providerAccreditationPartnershipRevision.js
+++ b/app/models/providerAccreditationPartnershipRevision.js
@@ -47,29 +47,6 @@ module.exports = (sequelize) => {
         allowNull: false,
         field: 'created_at'
       },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
-      },
       revisionNumber: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/app/models/providerAccreditationRevision.js
+++ b/app/models/providerAccreditationRevision.js
@@ -50,34 +50,6 @@ module.exports = (sequelize) => {
         type: DataTypes.DATE,
         field: 'ends_on'
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
-      },
       revisionNumber: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/app/models/providerAddressRevision.js
+++ b/app/models/providerAddressRevision.js
@@ -82,34 +82,6 @@ module.exports = (sequelize) => {
         type: DataTypes.STRING,
         field: 'google_place_id'
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
-      },
       revisionNumber: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/app/models/providerContactRevision.js
+++ b/app/models/providerContactRevision.js
@@ -62,34 +62,6 @@ module.exports = (sequelize) => {
           is: /^(?:(?:\(?(?:0(?:0|11)\)?[\s-]?\(?|\+)44\)?[\s-]?(?:\(?0\)?[\s-]?)?)|(?:\(?0))(?:(?:\d{5}\)?[\s-]?\d{4,5})|(?:\d{4}\)?[\s-]?(?:\d{5}|\d{3}[\s-]?\d{3}))|(?:\d{3}\)?[\s-]?\d{3}[\s-]?\d{3,4})|(?:\d{2}\)?[\s-]?\d{4}[\s-]?\d{4}))(?:[\s-]?(?:x|ext\.?|\#)\d{3,4})?$/
         }
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
-      },
       revisionNumber: {
         type: DataTypes.INTEGER,
         allowNull: false,

--- a/app/models/providerRevision.js
+++ b/app/models/providerRevision.js
@@ -70,26 +70,6 @@ module.exports = (sequelize) => {
           isURL: true
         }
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
       archivedAt: {
         type: DataTypes.DATE,
         field: 'archived_at'
@@ -97,14 +77,6 @@ module.exports = (sequelize) => {
       archivedById: {
         type: DataTypes.UUID,
         field: 'archived_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
       },
       revisionNumber: {
         type: DataTypes.INTEGER,

--- a/app/models/userRevision.js
+++ b/app/models/userRevision.js
@@ -61,34 +61,6 @@ module.exports = (sequelize) => {
         allowNull: false,
         defaultValue: true
       },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      createdById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'created_by_id'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      updatedById: {
-        type: DataTypes.UUID,
-        allowNull: false,
-        field: 'updated_by_id'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      },
-      deletedById: {
-        type: DataTypes.UUID,
-        field: 'deleted_by_id'
-      },
       revisionNumber: {
         type: DataTypes.INTEGER,
         allowNull: false,


### PR DESCRIPTION
This PR simplifies the `*-revision` tables for the activity log by removing the following duplicate fields:

- `changed_at`
- `changed_by_id`
- `updated_at`
- `updated_by_id`
- `deleted_at`
- `deleted_by_id`

The revision tables already have `revision_at` and `revision_by_id` fields that capture this information.

This PR also adds indexes to the ID fields in the revision tables.