### PR TITLE
Update activity logs

### DIFF
--- a/app/migrations/20250509143902-create-activity-log.js
+++ b/app/migrations/20250509143902-create-activity-log.js
@@ -44,16 +44,6 @@ module.exports = {
         type: Sequelize.DATE,
         allowNull: false,
         defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
-      },
-      created_at: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
-      },
-      updated_at: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
       }
     })
 

--- a/app/models/activityLog.js
+++ b/app/models/activityLog.js
@@ -108,6 +108,8 @@ module.exports = (sequelize) => {
       sequelize,
       modelName: 'ActivityLog',
       tableName: 'activity_logs',
+      // Important: no automatic timestamps on this table
+      timestamps: false, // disables both createdAt/updatedAt automation
       underscored: true
     }
   )

--- a/app/seeders/helpers/createActivityLog.js
+++ b/app/seeders/helpers/createActivityLog.js
@@ -20,9 +20,7 @@ const createActivityLog = async ({
     revision_number: revisionNumber,
     action: 'create',
     changed_by_id: changedById,
-    changed_at: now,
-    created_at: now,
-    updated_at: now
+    changed_at: now
   }], { transaction })
 }
 


### PR DESCRIPTION
This PR simplifies the `activity_logs` table by removing the duplicate `created_at` and `updated_at` fields. We do not update or delete data from the activity log, so these fields are unnecessary. Instead, we use the `changed_at` field.