### PR TITLE
Create partials for activity log views

### DIFF
--- a/app/helpers/content.js
+++ b/app/helpers/content.js
@@ -77,13 +77,9 @@ const formatLastUpdatedDisplay = (result) => {
   const dateStr = govukDateTime(date)
 
   const name = result.changedByUser
-    ? [result.changedByUser.firstName, result.changedByUser.lastName]
-        .filter(Boolean)
-        .join(' ') || result.changedByUser.email || 'Unknown'
+    ? [result.changedByUser.firstName, result.changedByUser.lastName].filter(Boolean).join(' ') || result.changedByUser.email || 'Unknown'
     : 'Unknown'
-
-  const verb = result.action === 'create' ? 'Created' : 'Last updated'
-  return `${verb} ${dateStr} by ${name}`
+  return `Last updated ${dateStr} by ${name}`
 }
 
 module.exports = {

--- a/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
+++ b/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
@@ -1,3 +1,10 @@
+{% set isPartnershipDeleted = false %}
+{% for field in item.summary.fields %}
+  {% if field.key == "Linked accreditations" and field.value == "None" %}
+    {% set isPartnershipDeleted = true %}
+  {% endif %}
+{% endfor %}
+
 <h3 class="govuk-summary-card__title">
   {{ item.summary.activity }}
 </h3>
@@ -19,19 +26,32 @@
     </div>
   {% endif %}
   <div class="govuk-summary-card__content">
-    {% for field in item.summary.fields %}
-      {# {% if not (field.key == "Linked accreditations" and field.value == "None") %} #}
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              {{ field.key }}
-            </dt>
-            <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
-              {{ field.value if field.value else "Not entered" }}
-            </dd>
-          </div>
-        </dl>
-      {# {% endif %} #}
-    {% endfor %}
+    <dl class="govuk-summary-list">
+      {% for field in item.summary.fields %}
+        {% if isPartnershipDeleted %}
+          {% if field.key in ["Accredited provider", "Training partner"] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                {{ field.key }}
+              </dt>
+              <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+                {{ field.value if field.value else "Not entered" }}
+              </dd>
+            </div>
+          {% endif %}
+        {% else %}
+          {% if not field.key in ["Accreditations added", "Accreditations removed"] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                {{ field.key }}
+              </dt>
+              <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+                {{ field.value if field.value else "Not entered" }}
+              </dd>
+            </div>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    </dl>
   </div>
 </div>

--- a/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
+++ b/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
@@ -1,0 +1,37 @@
+<h3 class="govuk-summary-card__title">
+  {{ item.summary.activity }}
+</h3>
+<p class="govuk-body">
+  By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
+</p>
+<div class="govuk-summary-card">
+  {% if showSummaryCardTitle %}
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">
+        {% if item.summary.labelHtml | length %}
+          {{ item.summary.labelHtml | safe }}
+        {% else %}
+          <a href="{{ item.summary.href }}" class="govuk-link">
+            {{ item.summary.label }}
+          </a>
+        {% endif %}
+      </h2>
+    </div>
+  {% endif %}
+  <div class="govuk-summary-card__content">
+    {% for field in item.summary.fields %}
+      {# {% if not (field.key == "Linked accreditations" and field.value == "None") %} #}
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              {{ field.key }}
+            </dt>
+            <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+              {{ field.value if field.value else "Not entered" }}
+            </dd>
+          </div>
+        </dl>
+      {# {% endif %} #}
+    {% endfor %}
+  </div>
+</div>

--- a/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
+++ b/app/views/_includes/activity/provider-accreditation-partnership-revisions.njk
@@ -29,7 +29,7 @@
     <dl class="govuk-summary-list">
       {% for field in item.summary.fields %}
         {% if isPartnershipDeleted %}
-          {% if field.key in ["Accredited provider", "Training partner"] %}
+          {% if field.key in ["Accredited provider", "Training partner", "Accreditations removed"] %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 {{ field.key }}

--- a/app/views/_includes/activity/provider-address-revisions.njk
+++ b/app/views/_includes/activity/provider-address-revisions.njk
@@ -1,0 +1,58 @@
+<h3 class="govuk-summary-card__title">
+  {{ item.summary.activity }}
+</h3>
+<p class="govuk-body">
+  By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
+</p>
+<div class="govuk-summary-card">
+  {% if showSummaryCardTitle %}
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">
+        {% if item.summary.labelHtml | length %}
+          {{ item.summary.labelHtml | safe }}
+        {% else %}
+          <a href="{{ item.summary.href }}" class="govuk-link">
+            {{ item.summary.label }}
+          </a>
+        {% endif %}
+      </h2>
+    </div>
+  {% endif %}
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Address
+        </dt>
+        <dd class="govuk-summary-list__value">
+        {% for field in item.summary.fields %}
+          {% if field.key in ["Address line 1", "Address line 2", "Address line 3", "Town or city", "Postcode"] %}
+            {{ field.value if field.value }}{% if field.value | length %}<br>{% endif %}
+          {% endif %}
+        {% endfor %}
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Location
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <dl class="govuk-summary-list">
+            {% for field in item.summary.fields %}
+              {% if field.key in ["Latitude", "Longitude"] %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    {{ field.key }}
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {{ field.value if field.value }}
+                  </dd>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </dl>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/_includes/activity/provider-revisions.njk
+++ b/app/views/_includes/activity/provider-revisions.njk
@@ -1,0 +1,37 @@
+<h3 class="govuk-summary-card__title">
+  {{ item.summary.activity }}
+</h3>
+<p class="govuk-body">
+  By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
+</p>
+<div class="govuk-summary-card">
+  {% if showSummaryCardTitle %}
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">
+        {% if item.summary.labelHtml | length %}
+          {{ item.summary.labelHtml | safe }}
+        {% else %}
+          <a href="{{ item.summary.href }}" class="govuk-link">
+            {{ item.summary.label }}
+          </a>
+        {% endif %}
+      </h2>
+    </div>
+  {% endif %}
+  <div class="govuk-summary-card__content">
+    {% for field in item.summary.fields %}
+      {% if not (field.key == "Linked accreditations" and field.value == "None") %}
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              {{ field.key }}
+            </dt>
+            <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+              {{ field.value if field.value else "Not entered" }}
+            </dd>
+          </div>
+        </dl>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>

--- a/app/views/_includes/activity/provider-revisions.njk
+++ b/app/views/_includes/activity/provider-revisions.njk
@@ -19,8 +19,8 @@
     </div>
   {% endif %}
   <div class="govuk-summary-card__content">
-    {% for field in item.summary.fields %}
-      <dl class="govuk-summary-list">
+    <dl class="govuk-summary-list">
+      {% for field in item.summary.fields %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             {{ field.key }}
@@ -29,7 +29,7 @@
             {{ field.value if field.value else "Not entered" }}
           </dd>
         </div>
-      </dl>
-    {% endfor %}
+      {% endfor %}
+    </dl>
   </div>
 </div>

--- a/app/views/_includes/activity/provider-revisions.njk
+++ b/app/views/_includes/activity/provider-revisions.njk
@@ -20,18 +20,16 @@
   {% endif %}
   <div class="govuk-summary-card__content">
     {% for field in item.summary.fields %}
-      {% if not (field.key == "Linked accreditations" and field.value == "None") %}
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              {{ field.key }}
-            </dt>
-            <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
-              {{ field.value if field.value else "Not entered" }}
-            </dd>
-          </div>
-        </dl>
-      {% endif %}
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            {{ field.key }}
+          </dt>
+          <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
+            {{ field.value if field.value else "Not entered" }}
+          </dd>
+        </div>
+      </dl>
     {% endfor %}
   </div>
 </div>

--- a/app/views/activity/index.njk
+++ b/app/views/activity/index.njk
@@ -25,45 +25,18 @@
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         {% for item in group.entries %}
-          <h3 class="govuk-summary-card__title">
+          {# <h3 class="govuk-summary-card__title">
             {{ item.summary.activity }}
-          </h3>
-          <p class="govuk-body">
+          </h3> #}
+          {# <p class="govuk-body">
             {% if item.changedByUser.deleteById %}
-              By Deleted user on {{ item.changedAt | govukDateTime }}
+            By Deleted user on {{ item.changedAt | govukDateTime }}
             {% else %}
-              By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
+            By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
             {% endif %}
-          </p>
-          <div class="govuk-summary-card">
-            <div class="govuk-summary-card__title-wrapper">
-              <h2 class="govuk-summary-card__title">
-                {% if item.summary.labelHtml | length %}
-                  {{ item.summary.labelHtml | safe }}
-                {% else %}
-                  <a href="{{ item.summary.href }}" class="govuk-link">
-                    {{ item.summary.label }}
-                  </a>
-                {% endif %}
-              </h2>
-            </div>
-            <div class="govuk-summary-card__content">
-              {% for field in item.summary.fields %}
-                {% if not (field.key == "Linked accreditations" and field.value == "None") %}
-                  <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row">
-                      <dt class="govuk-summary-list__key">
-                        {{ field.key }}
-                      </dt>
-                      <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
-                        {{ field.value if field.value else "Not entered" }}
-                      </dd>
-                    </div>
-                  </dl>
-                {% endif %}
-              {% endfor %}
-            </div>
-          </div>
+          </p> #}
+          {% set showSummaryCardTitle = true %}
+          {% include "_includes/activity/provider-revisions.njk" %}
         {% endfor %}
       {% endfor %}
 

--- a/app/views/activity/index.njk
+++ b/app/views/activity/index.njk
@@ -25,18 +25,14 @@
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         {% for item in group.entries %}
-          {# <h3 class="govuk-summary-card__title">
-            {{ item.summary.activity }}
-          </h3> #}
-          {# <p class="govuk-body">
-            {% if item.changedByUser.deleteById %}
-            By Deleted user on {{ item.changedAt | govukDateTime }}
-            {% else %}
-            By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
-            {% endif %}
-          </p> #}
           {% set showSummaryCardTitle = true %}
-          {% include "_includes/activity/provider-revisions.njk" %}
+          {% if item.revisionTable == "provider_accreditation_partnership_revisions" %}
+            {% include "_includes/activity/provider-accreditation-partnership-revisions.njk" %}
+          {% elif item.revisionTable == "provider_address_revisions" %}
+            {% include "_includes/activity/provider-address-revisions.njk" %}
+          {% else %}
+            {% include "_includes/activity/provider-revisions.njk" %}
+          {% endif %}
         {% endfor %}
       {% endfor %}
 

--- a/app/views/providers/activity/index.njk
+++ b/app/views/providers/activity/index.njk
@@ -39,8 +39,13 @@
     {% if activityItems.length %}
 
       {% for item in activityItems %}
-
-        {% include "_includes/activity/provider-revisions.njk" %}
+        {% if item.revisionTable == "provider_accreditation_partnership_revisions" %}
+          {% include "_includes/activity/provider-accreditation-partnership-revisions.njk" %}
+        {% elif item.revisionTable == "provider_address_revisions" %}
+          {% include "_includes/activity/provider-address-revisions.njk" %}
+        {% else %}
+          {% include "_includes/activity/provider-revisions.njk" %}
+        {% endif %}
       {% endfor %}
 
       {% include "_includes/pagination.njk" %}

--- a/app/views/providers/activity/index.njk
+++ b/app/views/providers/activity/index.njk
@@ -39,30 +39,8 @@
     {% if activityItems.length %}
 
       {% for item in activityItems %}
-        <h3 class="govuk-summary-card__title">
-          {{ item.summary.activity }}
-        </h3>
-        <p class="govuk-body">
-          By {{ item.changedByUser.firstName + " " + item.changedByUser.lastName }} on {{ item.changedAt | govukDateTime }}
-        </p>
-        <div class="govuk-summary-card">
-          <div class="govuk-summary-card__content">
-            {% for field in item.summary.fields %}
-              {% if not (field.key == "Linked accreditations" and field.value == "None") %}
-                <dl class="govuk-summary-list">
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                      {{ field.key }}
-                    </dt>
-                    <dd class="govuk-summary-list__value {{- ' govuk-hint' if not field.value }}">
-                      {{ field.value if field.value else "Not entered" }}
-                    </dd>
-                  </div>
-                </dl>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </div>
+
+        {% include "_includes/activity/provider-revisions.njk" %}
       {% endfor %}
 
       {% include "_includes/pagination.njk" %}


### PR DESCRIPTION
This PR introduces three partials for the activity logs:

- provider - the default view
- provider address
- provider accreditation partnership

These partials enable us to display content in the activity log, as it is shown in the equivalent sections of the service.